### PR TITLE
Add TOML config parser with runtime reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ Tests and linting only trigger when code changes occur—documentation updates
 or comment-only edits are ignored. If `pyproject.toml` is missing, Ruff runs
 directly and tests are skipped.
 
+
+## Configuration
+
+Use the `Config` class in `agents.config` to load settings from a TOML file. The
+configuration automatically reloads when the process receives a `SIGHUP` signal.
+
+```python
+from agents.config import Config
+
+cfg = Config("settings.toml")
+value = cfg.get("some_key")
+```
+
+Sending `SIGHUP` causes `cfg` to reload the file at runtime.

--- a/agents/config.py
+++ b/agents/config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import signal
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+class Config:
+    """Simple TOML configuration parser with reload on SIGHUP."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.data: dict[str, Any] = {}
+        self.load()
+        signal.signal(signal.SIGHUP, self._handle_sighup)
+
+    def load(self) -> None:
+        """Load configuration from ``self.path``."""
+        with self.path.open("rb") as f:
+            self.data = tomllib.load(f)
+
+    def reload(self) -> None:
+        """Reload configuration from disk."""
+        self.load()
+
+    def _handle_sighup(self, signum: int, frame: object) -> None:  # pragma: no cover - signal handler
+        self.reload()
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve a value from the configuration."""
+        return self.data.get(key, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ package-mode = false
 
 [tool.poetry.workspace]
 packages = [
-    {include = "agents.core"},
-    {include = "agents.experimental"},
+    {include = "agents"},
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents.config import Config
+
+
+def test_load_and_get(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("a = 1\n[b]\nc = 'd'")
+
+    cfg = Config(config_file)
+
+    assert cfg.get("a") == 1
+    assert cfg.get("b") == {"c": "d"}


### PR DESCRIPTION
## Summary
- add `agents.config` with a TOML config parser
- automatically reload configuration on SIGHUP
- document config usage in README
- include simple tests for config loader
- update pyproject to expose the `agents` package

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be06cc814832690e83801791a7254