### PR TITLE
Add async FinanceAdvisor agent

### DIFF
--- a/agents/finance_advisor/__init__.py
+++ b/agents/finance_advisor/__init__.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Sequence
+import math
+
+from ..sdk import BaseAgent
+
+logger = logging.getLogger(__name__)
+
+
+def percentile(data: Sequence[float], p: float) -> float:
+    """Return the ``p``th percentile of ``data`` (``p`` between 0 and 100)."""
+    if not data:
+        raise ValueError("data must not be empty")
+    if not 0 <= p <= 100:
+        raise ValueError("percentile must be between 0 and 100")
+    s = sorted(data)
+    k = (len(s) - 1) * (p / 100)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return s[int(k)]
+    d0 = s[f] * (c - k)
+    d1 = s[c] * (k - f)
+    return d0 + d1
+
+
+def percentile_zscore(history: Sequence[float], value: float) -> float:
+    """Compute the percentile z-score for ``value`` given ``history``."""
+    if not history:
+        return 0.0
+    p50 = percentile(history, 50)
+    p90 = percentile(history, 90)
+    p10 = percentile(history, 10)
+    scale = p90 - p10
+    if scale == 0:
+        return 0.0
+    return (value - p50) / scale
+
+
+class FinanceAdvisor(BaseAgent):
+    """Agent that flags anomalous transactions using percentile z-scores."""
+
+    def __init__(self, *, bootstrap_servers: str = "localhost:9092") -> None:
+        super().__init__(
+            "ume.events.transaction.created",
+            bootstrap_servers=bootstrap_servers,
+            group_id="finance-advisor",
+        )
+        self.amounts: list[float] = []
+
+    def handle_event(self, event: dict[str, float]) -> None:  # type: ignore[override]
+        amount = event.get("amount")
+        if amount is None:
+            logger.debug("Received event without amount: %s", event)
+            return
+        self.amounts.append(float(amount))
+        score = percentile_zscore(self.amounts, float(amount))
+        logger.info("Transaction %s has z-score %.2f", amount, score)
+        if abs(score) > 3:
+            self.emit(
+                "ume.events.transaction.anomaly",
+                {"amount": amount, "z": score},
+            )
+
+
+async def main() -> None:
+    """Asynchronous entrypoint for the finance advisor agent."""
+    agent = FinanceAdvisor()
+    await asyncio.to_thread(agent.run)
+
+
+__all__ = ["FinanceAdvisor", "percentile", "percentile_zscore", "main"]

--- a/agents/finance_advisor/__main__.py
+++ b/agents/finance_advisor/__main__.py
@@ -1,0 +1,5 @@
+from . import main
+import asyncio
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+import sys
+from pathlib import Path as _Path
+sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
 
 from pathlib import Path
 

--- a/tests/test_finance_advisor.py
+++ b/tests/test_finance_advisor.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from agents.finance_advisor import percentile, percentile_zscore
+
+
+def test_percentile() -> None:
+    data = [1, 2, 3, 4, 5]
+    assert percentile(data, 50) == 3
+    assert percentile(data, 0) == 1
+    assert percentile(data, 100) == 5
+
+
+def test_percentile_zscore() -> None:
+    history = [10, 20, 30, 40, 50]
+    value = 60
+    score = percentile_zscore(history, value)
+    assert score > 0


### PR DESCRIPTION
## Summary
- add new `finance_advisor` package with async entrypoint
- flag anomalous transactions using percentile z-score
- add tests for percentile helpers
- adjust test paths to allow importing `agents`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c07b51cc8832683f307045ab08d58