### PR TITLE
Add FinRL strategist package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ value = cfg.get("some_key")
 ```
 
 Sending `SIGHUP` causes `cfg` to reload the file at runtime.
+
+## FinRL Strategist
+
+The package `agents.finrl_strategist` integrates the [FinRL](https://github.com/AI4Finance-Foundation/FinRL) framework.
+It exposes a `FinRLStrategist` class that executes a 30‑day back‑test using a DRL policy. The strategists only run
+on Mondays via the `run_weekly` method, which loads the latest 30 days of market data and trains a PPO model before
+producing predictions.

--- a/agents/finrl_strategist/__init__.py
+++ b/agents/finrl_strategist/__init__.py
@@ -1,0 +1,67 @@
+"""FinRL-based strategist with weekly scheduling and 30-day backtests."""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class FinRLStrategist:
+    """Run FinRL policies on a weekly schedule with 30-day backtests."""
+
+    def __init__(self, tickers: list[str]):
+        self.tickers = tickers
+
+    def _load_data(self, start: date, end: date):
+        """Load historical data using FinRL's YahooDownloader."""
+        try:
+            from finrl.marketdata.yahoodownloader import YahooDownloader
+        except Exception as exc:  # pragma: no cover - runtime dependency
+            raise RuntimeError("FinRL is required for data loading") from exc
+        downloader = YahooDownloader(
+            start_date=start.strftime("%Y-%m-%d"),
+            end_date=end.strftime("%Y-%m-%d"),
+            ticker_list=self.tickers,
+        )
+        return downloader.fetch_data()
+
+    def backtest_last_30d(self, as_of: date | None = None) -> Any:
+        """Back-test the strategy on the last 30 days of data."""
+        as_of = as_of or date.today()
+        start = as_of - timedelta(days=30)
+        data = self._load_data(start, as_of)
+        try:
+            from finrl.agents.stablebaselines3.models import DRLAgent
+            from finrl.meta.env_stock_trading.env_stocktrading import StockTradingEnv
+        except Exception as exc:  # pragma: no cover - runtime dependency
+            raise RuntimeError("FinRL full installation required") from exc
+        env = StockTradingEnv(
+            df=data,
+            stock_dim=len(self.tickers),
+            hmax=100,
+            initial_amount=1_000_000,
+            buy_cost_pct=0.001,
+            sell_cost_pct=0.001,
+            state_space=8 * len(self.tickers),
+            tech_indicator_list=[],
+            action_space=len(self.tickers),
+            reward_scaling=1,
+        )
+        agent = DRLAgent(env=env)
+        model = agent.get_model("ppo")
+        trained = agent.train_model(model)
+        return agent.DRL_prediction(model=trained, environment=env)
+
+    def run_weekly(self) -> Any | None:
+        """Run ``backtest_last_30d`` every Monday."""
+        today = date.today()
+        if today.weekday() != 0:
+            logger.info("FinRLStrategist: not Monday, skipping run")
+            return None
+        logger.info("Running FinRLStrategist backtest for %s", today.isoformat())
+        return self.backtest_last_30d(today)
+
+
+__all__ = ["FinRLStrategist"]


### PR DESCRIPTION
## Summary
- implement new `finrl_strategist` package
- update README with usage note about FinRL strategist

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c07b5d7988326bc1385cc7ed5a626