### PR TITLE
Add CryptoBot with Freqtrade integration

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+from .config import Config
+from .crypto_bot import CryptoBot
+from .sdk import emit_event, ume_query, BaseAgent
+
+__all__ = ["Config", "CryptoBot", "emit_event", "ume_query", "BaseAgent"]

--- a/agents/crypto_bot.py
+++ b/agents/crypto_bot.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import ccxt
+import yaml
+
+from .config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class CryptoBot:
+    """Simple wrapper around the Freqtrade engine."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.strategy: dict[str, Any] = {}
+        self.exchange: Any | None = None
+        self.engine: Any | None = None
+
+    def load_strategy(self) -> None:
+        """Load strategy YAML defined in the ``crypto_bot.strategy`` config key."""
+        path = self.config.get("crypto_bot", {}).get("strategy")
+        if not path:
+            raise ValueError("Strategy path not configured")
+        with Path(path).open("r") as f:
+            self.strategy = yaml.safe_load(f)
+        logger.info("Loaded strategy from %s", path)
+
+    def connect_exchange(self) -> None:
+        """Connect to the exchange defined in the strategy."""
+        name = self.strategy.get("exchange")
+        if not name:
+            raise ValueError("Strategy missing 'exchange' field")
+        name = name.lower()
+        if name == "binance":
+            cls = ccxt.binance
+        elif name == "kraken":
+            cls = ccxt.kraken
+        else:
+            raise ValueError(f"Unsupported exchange: {name}")
+        self.exchange = cls({"enableRateLimit": True})
+        logger.info("Connected to %s", name)
+
+    def init_engine(self) -> None:
+        """Initialize the Freqtrade engine."""
+        try:
+            from freqtrade.worker import Worker  # type: ignore
+            from freqtrade.configuration import Configuration  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("Freqtrade is not installed") from exc
+
+        ft_config = Configuration(self.config.data, None).get_config()
+        self.engine = Worker({}, config=ft_config)
+        logger.info("Freqtrade engine initialized")
+
+    def run(self) -> None:
+        """Run the bot."""
+        self.load_strategy()
+        self.connect_exchange()
+        self.init_engine()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from agents.config import Config
 

--- a/tests/test_crypto_bot.py
+++ b/tests/test_crypto_bot.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.config import Config
+from agents.crypto_bot import CryptoBot
+
+
+def test_load_strategy_and_connect(tmp_path):
+    cfg_file = tmp_path / "cfg.toml"
+    strat_file = tmp_path / "strategy.yaml"
+    strat_file.write_text("exchange: binance\n")
+    cfg_file.write_text(f"[crypto_bot]\nstrategy = '{strat_file}'\n")
+
+    bot = CryptoBot(Config(cfg_file))
+    bot.load_strategy()
+    assert bot.strategy == {"exchange": "binance"}
+
+    with patch("ccxt.binance") as binance_cls:
+        binance_cls.return_value = MagicMock()
+        bot.connect_exchange()
+        binance_cls.assert_called_once()
+
+
+def test_init_engine_uses_freqtrade_modules(tmp_path):
+    cfg_file = tmp_path / "cfg.toml"
+    strat_file = tmp_path / "strategy.yaml"
+    strat_file.write_text("exchange: binance\n")
+    cfg_file.write_text(f"[crypto_bot]\nstrategy = '{strat_file}'\n")
+
+    fake_worker_module = ModuleType("freqtrade.worker")
+    fake_configuration_module = ModuleType("freqtrade.configuration")
+    fake_worker_module.Worker = MagicMock()
+    fake_configuration_module.Configuration = MagicMock(return_value=MagicMock(get_config=MagicMock(return_value={})))
+    with patch.dict(sys.modules, {
+        "freqtrade.worker": fake_worker_module,
+        "freqtrade.configuration": fake_configuration_module,
+    }):
+        bot = CryptoBot(Config(cfg_file))
+        bot.strategy = {"exchange": "binance"}
+        bot.init_engine()
+        assert bot.engine is fake_worker_module.Worker.return_value


### PR DESCRIPTION
## Summary
- integrate initial CryptoBot implementation
- expose CryptoBot in package init
- unit tests for CryptoBot

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c07b671c883269b55373becf7298e