### PR TITLE
Add CLI entrypoints for agents

### DIFF
--- a/agents/crypto_bot/__init__.py
+++ b/agents/crypto_bot/__init__.py
@@ -4,10 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import ccxt
-import yaml
-
-from .config import Config
+from ..config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +20,7 @@ class CryptoBot:
 
     def load_strategy(self) -> None:
         """Load strategy YAML defined in the ``crypto_bot.strategy`` config key."""
+        import yaml
         path = self.config.get("crypto_bot", {}).get("strategy")
         if not path:
             raise ValueError("Strategy path not configured")
@@ -32,6 +30,7 @@ class CryptoBot:
 
     def connect_exchange(self) -> None:
         """Connect to the exchange defined in the strategy."""
+        import ccxt
         name = self.strategy.get("exchange")
         if not name:
             raise ValueError("Strategy missing 'exchange' field")

--- a/agents/crypto_bot/__main__.py
+++ b/agents/crypto_bot/__main__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from . import CryptoBot
+from ..config import Config
+
+
+async def main() -> None:
+    bot = CryptoBot(Config(Path("config.toml")))
+    await asyncio.to_thread(bot.run)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agents/finrl_strategist/__main__.py
+++ b/agents/finrl_strategist/__main__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import asyncio
+
+from . import FinRLStrategist
+
+
+async def main() -> None:
+    strategist = FinRLStrategist(["SPY"])
+    await asyncio.to_thread(strategist.run_weekly)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ packages = [
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
+
+[tool.poetry.scripts]
+crypto-bot = "agents.crypto_bot.__main__:main"
+finrl-strategist = "agents.finrl_strategist.__main__:main"

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
+    # Create minimal config and strategy
+    (tmp_path / "config.toml").write_text("[crypto_bot]\nstrategy = 'strategy.yaml'\n")
+    (tmp_path / "strategy.yaml").write_text("exchange: binance\n")
+
+    # Stub required external modules
+    (tmp_path / "ccxt").mkdir()
+    (tmp_path / "ccxt" / "__init__.py").write_text(
+        "class binance:\n    def __init__(self, *a, **k):\n        pass\nclass kraken:\n    def __init__(self, *a, **k):\n        pass\n"
+    )
+    (tmp_path / "freqtrade").mkdir()
+    (tmp_path / "freqtrade" / "__init__.py").write_text("")
+    (tmp_path / "freqtrade" / "worker.py").write_text(
+        "class Worker:\n    def __init__(self, *a, **k):\n        pass\n"
+    )
+    (tmp_path / "freqtrade" / "configuration.py").write_text(
+        "class Configuration:\n    def __init__(self, *a):\n        pass\n    def get_config(self):\n        return {}\n"
+    )
+
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])
+
+    result = subprocess.run(
+        [sys.executable, "-m", "agents.crypto_bot"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_finrl_strategist_entrypoint() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "agents.finrl_strategist"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- turn `crypto_bot` into a package and expose async CLI
- add CLI module for `finrl_strategist`
- wire entrypoints in `pyproject.toml`
- test entrypoints using subprocess

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb63b7cc8832681a3a7aa8d351e81