### PR TITLE
Implement CalendarSync agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,5 +1,13 @@
 from .config import Config
 from .crypto_bot import CryptoBot
+from .calendar_sync import CalendarSync
 from .sdk import emit_event, ume_query, BaseAgent
 
-__all__ = ["Config", "CryptoBot", "emit_event", "ume_query", "BaseAgent"]
+__all__ = [
+    "Config",
+    "CryptoBot",
+    "CalendarSync",
+    "emit_event",
+    "ume_query",
+    "BaseAgent",
+]

--- a/agents/calendar_sync/__init__.py
+++ b/agents/calendar_sync/__init__.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import requests
+
+from ..sdk import BaseAgent
+
+logger = logging.getLogger(__name__)
+
+
+class CalendarSync(BaseAgent):
+    """Synchronize Cal.com webhooks with UME appointment nodes."""
+
+    def __init__(self, cal_endpoint: str, *, bootstrap_servers: str = "localhost:9092") -> None:
+        super().__init__(
+            "ume.nodes.appointment",
+            bootstrap_servers=bootstrap_servers,
+            group_id="calendar-sync",
+        )
+        self.cal_endpoint = cal_endpoint
+
+    def handle_event(self, event: dict[str, Any]) -> None:  # type: ignore[override]
+        """Handle appointment updates from UME."""
+        appointment_id = event.get("id")
+        start = event.get("time")
+        if appointment_id is None or start is None:
+            logger.debug("Invalid UME event: %s", event)
+            return
+        try:
+            requests.post(
+                self.cal_endpoint,
+                json={"id": appointment_id, "time": start},
+                timeout=10,
+            )
+            logger.info("Synced appointment %s to Cal.com", appointment_id)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to sync to Cal.com: %s", exc)
+
+    def handle_cal_event(self, event: dict[str, Any]) -> None:
+        """Process a webhook payload from Cal.com."""
+        appointment_id = event.get("id")
+        start = event.get("time")
+        if appointment_id is None or start is None:
+            logger.debug("Invalid Cal.com event: %s", event)
+            return
+        self.emit(
+            "ume.events.task.reschedule",
+            {"id": appointment_id, "time": start},
+        )
+        logger.info("Emitted TaskReschedule for %s", appointment_id)
+
+
+async def main() -> None:
+    """Entry point for running ``CalendarSync`` asynchronously."""
+    agent = CalendarSync(cal_endpoint="http://localhost/api/cal")
+    await asyncio.to_thread(agent.run)
+
+
+__all__ = ["CalendarSync", "main"]

--- a/agents/calendar_sync/__main__.py
+++ b/agents/calendar_sync/__main__.py
@@ -1,0 +1,5 @@
+from . import main
+import asyncio
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.calendar_sync import CalendarSync
+
+
+def test_handle_event_posts_to_cal():
+    with patch("agents.sdk.base.KafkaConsumer"), patch("agents.sdk.base.KafkaProducer"):
+        agent = CalendarSync("http://api")
+    with patch("agents.calendar_sync.requests.post") as mock_post:
+        agent.handle_event({"id": "1", "time": "t"})
+        mock_post.assert_called_once_with(
+            "http://api",
+            json={"id": "1", "time": "t"},
+            timeout=10,
+        )
+
+
+def test_handle_cal_event_emits_task_reschedule():
+    with patch("agents.sdk.base.KafkaConsumer"), patch("agents.sdk.base.KafkaProducer"):
+        agent = CalendarSync("http://api")
+    agent.emit = MagicMock()
+    agent.handle_cal_event({"id": "2", "time": "t"})
+    agent.emit.assert_called_once_with(
+        "ume.events.task.reschedule",
+        {"id": "2", "time": "t"},
+    )


### PR DESCRIPTION
## Summary
- add new CalendarSync agent for Cal.com <-> UME appointments
- export CalendarSync in package init
- provide entrypoint and bidirectional sync logic
- test calendar sync behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc297c5f88326918561aa0056d803