### PR TITLE
Add event emission for FinRL strategist

### DIFF
--- a/tests/test_finrl_strategist.py
+++ b/tests/test_finrl_strategist.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.finrl_strategist import FinRLStrategist
+
+
+class Monday(date):
+    @classmethod
+    def today(cls):
+        return cls(2024, 1, 1)
+
+
+def test_run_weekly_emits_signals():
+    strategist = FinRLStrategist(["SPY", "AAPL"])
+    predictions = {"SPY": "buy", "AAPL": "sell"}
+    with patch("agents.finrl_strategist.date", Monday), \
+         patch("agents.sdk.KafkaProducer") as mock_producer_cls, \
+         patch.object(FinRLStrategist, "backtest_last_30d", return_value=predictions):
+        mock_producer = MagicMock()
+        mock_producer_cls.return_value = mock_producer
+        result = strategist.run_weekly()
+        assert result == predictions
+        assert mock_producer.send.call_count == 2
+        assert mock_producer.flush.call_count == 2
+        assert mock_producer.close.call_count == 2


### PR DESCRIPTION
## Summary
- emit Buy/Sell signals after running FinRL backtests
- test run_weekly sends Kafka messages using patched producer

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd3d11a7c8326a5b744556260cb4f