### PR TITLE
Add Prometheus metrics to BaseAgent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ package-mode = false
 python = ">=3.11"
 kafka-python = "*"
 requests = "*"
+prometheus-client = "*"
 
 [tool.poetry.workspace]
 packages = [

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -10,7 +10,9 @@ from agents.calendar_sync import CalendarSync
 
 
 def test_handle_event_posts_to_cal():
-    with patch("agents.sdk.base.KafkaConsumer"), patch("agents.sdk.base.KafkaProducer"):
+    with patch("agents.sdk.base.KafkaConsumer"), \
+         patch("agents.sdk.base.KafkaProducer"), \
+         patch("agents.sdk.base.start_http_server"):
         agent = CalendarSync("http://api")
     with patch("agents.calendar_sync.requests.post") as mock_post:
         agent.handle_event({"id": "1", "time": "t"})
@@ -22,7 +24,9 @@ def test_handle_event_posts_to_cal():
 
 
 def test_handle_cal_event_emits_task_reschedule():
-    with patch("agents.sdk.base.KafkaConsumer"), patch("agents.sdk.base.KafkaProducer"):
+    with patch("agents.sdk.base.KafkaConsumer"), \
+         patch("agents.sdk.base.KafkaProducer"), \
+         patch("agents.sdk.base.start_http_server"):
         agent = CalendarSync("http://api")
     agent.emit = MagicMock()
     agent.handle_cal_event({"id": "2", "time": "t"})

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -57,6 +57,11 @@ def test_eureka_watcher_entrypoint(tmp_path: Path) -> None:
     (tmp_path / "requests" / "__init__.py").write_text(
         "def post(*a,**k):\n    class R:\n        def raise_for_status(self):\n            pass\n        def json(self):\n            return {'docs':[{'id':'d','vector':[1,0]}]}\n    return R()\n"
     )
+    # Stub prometheus_client to avoid starting an HTTP server
+    (tmp_path / "prometheus_client").mkdir()
+    (tmp_path / "prometheus_client" / "__init__.py").write_text(
+        "def start_http_server(*a, **k):\n    pass\nclass Counter:\n    def __init__(self,*a,**k):\n        pass\n    def labels(self, **k):\n        class L:\n            def inc(self,*a,**k):\n                pass\n        return L()\nclass Histogram:\n    def __init__(self,*a,**k):\n        pass\n    def labels(self, **k):\n        class L:\n            def observe(self,*a,**k):\n                pass\n        return L()\n"
+    )
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])

--- a/tests/test_eureka_watcher.py
+++ b/tests/test_eureka_watcher.py
@@ -20,6 +20,7 @@ def test_watcher_emits_for_similar_doc() -> None:
     with patch("agents.eureka_watcher.ume_query", return_value=docs), \
          patch("agents.sdk.base.KafkaConsumer"), \
          patch("agents.sdk.base.KafkaProducer"), \
+         patch("agents.sdk.base.start_http_server"), \
          patch.object(EurekaWatcher, "emit") as mock_emit:
         watcher = EurekaWatcher("http://example")
         watcher.handle_event(event)


### PR DESCRIPTION
## Summary
- expose Prometheus metrics in BaseAgent
- track message counts and processing duration
- stub metrics server in tests
- verify metrics increment during processing
- include prometheus-client dependency

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd3d0574c8326b618735c0ab67277