### PR TITLE
Add metrics emission for CryptoBot

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -24,6 +24,10 @@ def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
     (tmp_path / "freqtrade" / "configuration.py").write_text(
         "class Configuration:\n    def __init__(self, *a):\n        pass\n    def get_config(self):\n        return {}\n"
     )
+    (tmp_path / "kafka").mkdir()
+    (tmp_path / "kafka" / "__init__.py").write_text(
+        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\nclass KafkaProducer:\n    def __init__(self,*a,**k):\n        pass\n    def send(self,*a,**k):\n        pass\n    def flush(self):\n        pass\n    def close(self):\n        pass\n"
+    )
 
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- publish CryptoBot position and P/L metrics via `emit_event`
- stub Kafka in entrypoint tests
- test CryptoBot run emits metrics

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdc0a3f088326bf97cc2efcfc0d27