### PR TITLE
Add OPA sidecar routing for ume_query

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -27,6 +27,21 @@ def test_ume_query_posts_and_returns_json():
         mock_post.assert_called_once()
 
 
+def test_ume_query_uses_sidecar(monkeypatch):
+    with patch("agents.sdk.requests.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+        monkeypatch.setenv("OPA_SIDECAR_URL", "http://sidecar")
+        assert sdk.ume_query("http://example", {"a": 1}) == {"ok": True}
+        mock_post.assert_called_once_with(
+            "http://sidecar",
+            json={"url": "http://example", "payload": {"a": 1}},
+            timeout=10,
+        )
+
+
 def test_base_agent_dispatches_messages():
     with patch("agents.sdk.base.KafkaConsumer") as mock_consumer_cls, \
          patch("agents.sdk.base.KafkaProducer"), \


### PR DESCRIPTION
## Summary
- add ability to route UME requests through an OPA sidecar using `OPA_SIDECAR_URL`
- test that ume_query respects sidecar configuration

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdc0b1fcc8326b5e1738a219f563e