### PR TITLE
Extend FinRL strategist signals

### DIFF
--- a/agents/finrl_strategist/__init__.py
+++ b/agents/finrl_strategist/__init__.py
@@ -65,11 +65,11 @@ class FinRLStrategist:
         logger.info("Running FinRLStrategist backtest for %s", today.isoformat())
         result = self.backtest_last_30d(today)
         if isinstance(result, dict):
+            signals = {"buy": "BuySignal", "sell": "SellSignal"}
             for ticker, action in result.items():
-                if action == "buy":
-                    emit_event("BuySignal", {"ticker": ticker})
-                elif action == "sell":
-                    emit_event("SellSignal", {"ticker": ticker})
+                topic = signals.get(action)
+                if topic:
+                    emit_event(topic, {"ticker": ticker})
         return result
 
 

--- a/tests/test_finrl_strategist.py
+++ b/tests/test_finrl_strategist.py
@@ -29,3 +29,8 @@ def test_run_weekly_emits_signals():
         assert mock_producer.send.call_count == 2
         assert mock_producer.flush.call_count == 2
         assert mock_producer.close.call_count == 2
+        calls = [
+            (("BuySignal", {"ticker": "SPY"}),),
+            (("SellSignal", {"ticker": "AAPL"}),),
+        ]
+        assert mock_producer.send.call_args_list == calls


### PR DESCRIPTION
## Summary
- map actions to BuySignal/SellSignal in `FinRLStrategist.run_weekly`
- validate producer calls in strategist test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b9f1f0483269815ef8c953c7558