### PR TITLE
Add metrics server guard and test reset

### DIFF
--- a/agents/sdk/base.py
+++ b/agents/sdk/base.py
@@ -6,8 +6,9 @@ import time
 from typing import Any
 
 from prometheus_client import Counter, Histogram, start_http_server
-
 from kafka import KafkaConsumer, KafkaProducer
+
+_METRICS_STARTED = False
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,10 @@ class BaseAgent:
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
         )
         self._labels = {"agent": self.__class__.__name__}
-        if metrics_port is not None:
+        global _METRICS_STARTED
+        if metrics_port is not None and not _METRICS_STARTED:
             start_http_server(metrics_port)
+            _METRICS_STARTED = True
 
     def emit(self, topic: str, event: dict[str, Any]) -> None:
         """Emit an event to a Kafka topic."""

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,10 +1,19 @@
 from unittest.mock import MagicMock, patch
+import pytest
+import agents.sdk.base as base
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import agents.sdk as sdk
 from prometheus_client import CollectorRegistry, Counter, Histogram
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_started():
+    base._METRICS_STARTED = False
+    yield
+    base._METRICS_STARTED = False
 
 
 def test_emit_event_uses_kafka_producer():


### PR DESCRIPTION
## Summary
- start Prometheus server only once when metrics port is provided
- track counters and histograms for message metrics
- reset the metrics server flag between tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b9ea3188326bd3b2fa36e664e3b