### PR TITLE
Add TradeSummary event emission

### DIFF
--- a/agents/crypto_bot/__init__.py
+++ b/agents/crypto_bot/__init__.py
@@ -75,4 +75,4 @@ class CryptoBot:
         # After execution publish basic metrics.
         positions = getattr(self.engine, "positions", [])
         profit = getattr(self.engine, "profit", 0.0)
-        emit_event("PositionUpdate", {"positions": positions, "profit": profit})
+        emit_event("TradeSummary", {"positions": positions, "profit": profit})


### PR DESCRIPTION
## Summary
- emit `TradeSummary` after engine execution
- check for `TradeSummary` with mocked engine run
- ensure metrics event when the engine exposes `start`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2e589e2c8326ab7588c51992cff2