### PR TITLE
Add config path support in agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ value = cfg.get("some_key")
 
 Sending `SIGHUP` causes `cfg` to reload the file at runtime.
 
+All agents load configuration through the same mechanism. Specify the path
+with the `--config` command line option or `CONFIG_PATH` environment
+variable. If omitted, agents default to a `config.toml` file in the current
+directory.
+
 ## FinRL Strategist
 
 The package `agents.finrl_strategist` integrates the [FinRL](https://github.com/AI4Finance-Foundation/FinRL) framework.

--- a/agents/calendar_sync/__init__.py
+++ b/agents/calendar_sync/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 import requests
 
 from ..sdk import BaseAgent
+from ..config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +93,12 @@ class CalendarSync(BaseAgent):
             self._webhook_thread.join()
 
 
-async def main() -> None:
+async def main(config: Config | None = None) -> None:
     """Entry point for running ``CalendarSync`` asynchronously."""
-    agent = CalendarSync(cal_endpoint="http://localhost/api/cal")
+    section = config.get("calendar_sync", {}) if config else {}
+    endpoint = section.get("cal_endpoint", "http://localhost/api/cal")
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    agent = CalendarSync(endpoint, bootstrap_servers=bootstrap)
     agent.start_webhook_server()
     try:
         await asyncio.to_thread(agent.run)

--- a/agents/calendar_sync/__main__.py
+++ b/agents/calendar_sync/__main__.py
@@ -1,5 +1,22 @@
 from . import main
+import argparse
 import asyncio
+import os
+from pathlib import Path
+from ..config import Config
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(main(cfg))

--- a/agents/crypto_bot/__main__.py
+++ b/agents/crypto_bot/__main__.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
 from pathlib import Path
 
 from . import CryptoBot
 from ..config import Config
 
 
-async def _run() -> None:
-    bot = CryptoBot(Config(Path("config.toml")))
+async def _run(cfg_path: Path) -> None:
+    bot = CryptoBot(Config(cfg_path))
     await asyncio.to_thread(bot.run)
 
 
 def main() -> None:
-    asyncio.run(_run())
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    args = parser.parse_args()
+    asyncio.run(_run(Path(args.config)))
 
 
 if __name__ == "__main__":

--- a/agents/eureka_watcher/__init__.py
+++ b/agents/eureka_watcher/__init__.py
@@ -6,6 +6,7 @@ from math import sqrt
 from typing import Any, Sequence
 
 from ..sdk import BaseAgent, ume_query
+from ..config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +59,11 @@ class EurekaWatcher(BaseAgent):
                 )
 
 
-async def main() -> None:
-    watcher = EurekaWatcher("http://localhost:8000/docs")
+async def main(config: Config | None = None) -> None:
+    section = config.get("eureka_watcher", {}) if config else {}
+    endpoint = section.get("docs_endpoint", "http://localhost:8000/docs")
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    watcher = EurekaWatcher(endpoint, bootstrap_servers=bootstrap)
     await asyncio.to_thread(watcher.run)
 
 

--- a/agents/eureka_watcher/__main__.py
+++ b/agents/eureka_watcher/__main__.py
@@ -1,5 +1,22 @@
 from . import main
+import argparse
 import asyncio
+import os
+from pathlib import Path
+from ..config import Config
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(main(cfg))

--- a/agents/finance_advisor/__init__.py
+++ b/agents/finance_advisor/__init__.py
@@ -6,6 +6,7 @@ from typing import Sequence
 import math
 
 from ..sdk import BaseAgent
+from ..config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -66,9 +67,11 @@ class FinanceAdvisor(BaseAgent):
             )
 
 
-async def main() -> None:
+async def main(config: Config | None = None) -> None:
     """Asynchronous entrypoint for the finance advisor agent."""
-    agent = FinanceAdvisor()
+    section = config.get("finance_advisor", {}) if config else {}
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    agent = FinanceAdvisor(bootstrap_servers=bootstrap)
     await asyncio.to_thread(agent.run)
 
 

--- a/agents/finance_advisor/__main__.py
+++ b/agents/finance_advisor/__main__.py
@@ -1,5 +1,22 @@
 from . import main
+import argparse
 import asyncio
+import os
+from pathlib import Path
+from ..config import Config
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(main(cfg))

--- a/agents/finrl_strategist/__init__.py
+++ b/agents/finrl_strategist/__init__.py
@@ -1,11 +1,13 @@
 """FinRL-based strategist with weekly scheduling and 30-day backtests."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import date, timedelta
 from typing import Any
 
 from ..sdk import emit_event
+from ..config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -73,4 +75,11 @@ class FinRLStrategist:
         return result
 
 
-__all__ = ["FinRLStrategist"]
+async def main(config: Config | None = None) -> None:
+    section = config.get("finrl_strategist", {}) if config else {}
+    tickers = section.get("tickers", ["SPY"])
+    strategist = FinRLStrategist(list(tickers))
+    await asyncio.to_thread(strategist.run_weekly)
+
+
+__all__ = ["FinRLStrategist", "main"]

--- a/agents/finrl_strategist/__main__.py
+++ b/agents/finrl_strategist/__main__.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
+from pathlib import Path
 
-from . import FinRLStrategist
+from . import main as run_main
+from ..config import Config
 
 
-async def _run() -> None:
-    strategist = FinRLStrategist(["SPY"])
-    await asyncio.to_thread(strategist.run_weekly)
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
 
 
 def main() -> None:
-    asyncio.run(_run())
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(run_main(cfg))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow passing config path via `--config` or `CONFIG_PATH`
- update CalendarSync, EurekaWatcher, FinanceAdvisor and FinRLStrategist to read from Config
- expose new async `main` helpers in agents
- document the configuration option in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d59e2d6f083269c2d406ec4bcfbdd