### PR TITLE
Support multiple topics in BaseAgent

### DIFF
--- a/agents/calendar_sync/__init__.py
+++ b/agents/calendar_sync/__init__.py
@@ -18,9 +18,11 @@ logger = logging.getLogger(__name__)
 class CalendarSync(BaseAgent):
     """Synchronize Cal.com webhooks with UME appointment nodes."""
 
+    topic_subscriptions = ["ume.nodes.appointment"]
+
     def __init__(self, cal_endpoint: str, *, bootstrap_servers: str = "localhost:9092") -> None:
         super().__init__(
-            "ume.nodes.appointment",
+            self.topic_subscriptions,
             bootstrap_servers=bootstrap_servers,
             group_id="calendar-sync",
         )

--- a/agents/eureka_watcher/__init__.py
+++ b/agents/eureka_watcher/__init__.py
@@ -26,9 +26,11 @@ def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
 class EurekaWatcher(BaseAgent):
     """Watch IdeaSeed events and suggest tasks for similar docs."""
 
+    topic_subscriptions = ["ume.events.ideaseed"]
+
     def __init__(self, docs_endpoint: str, *, bootstrap_servers: str = "localhost:9092") -> None:
         super().__init__(
-            "ume.events.ideaseed", bootstrap_servers=bootstrap_servers, group_id="eureka-watcher"
+            self.topic_subscriptions, bootstrap_servers=bootstrap_servers, group_id="eureka-watcher"
         )
         self.docs_endpoint = docs_endpoint
 

--- a/agents/finance_advisor/__init__.py
+++ b/agents/finance_advisor/__init__.py
@@ -44,9 +44,11 @@ def percentile_zscore(history: Sequence[float], value: float) -> float:
 class FinanceAdvisor(BaseAgent):
     """Agent that flags anomalous transactions using percentile z-scores."""
 
+    topic_subscriptions = ["ume.events.transaction.created"]
+
     def __init__(self, *, bootstrap_servers: str = "localhost:9092") -> None:
         super().__init__(
-            "ume.events.transaction.created",
+            self.topic_subscriptions,
             bootstrap_servers=bootstrap_servers,
             group_id="finance-advisor",
         )


### PR DESCRIPTION
## Summary
- allow `BaseAgent` to subscribe to many topics
- declare topics at class level for FinanceAdvisor, CalendarSync and EurekaWatcher
- test handling multiple topics

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5ee2085483268adfbf24ab2b034a