### PR TITLE
Add edge case tests for percentile functions

### DIFF
--- a/tests/test_finance_advisor.py
+++ b/tests/test_finance_advisor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from agents.finance_advisor import percentile, percentile_zscore
+import pytest
 
 
 def test_percentile() -> None:
@@ -14,8 +15,29 @@ def test_percentile() -> None:
     assert percentile(data, 100) == 5
 
 
+def test_percentile_empty_list() -> None:
+    with pytest.raises(ValueError):
+        percentile([], 50)
+
+
+def test_percentile_negative_numbers() -> None:
+    data = [-5, -2, -1]
+    assert percentile(data, 50) == -2
+
+
 def test_percentile_zscore() -> None:
     history = [10, 20, 30, 40, 50]
     value = 60
+    score = percentile_zscore(history, value)
+    assert score > 0
+
+
+def test_percentile_zscore_empty_history() -> None:
+    assert percentile_zscore([], 10) == 0.0
+
+
+def test_percentile_zscore_negative_numbers() -> None:
+    history = [-30, -20, -10]
+    value = -5
     score = percentile_zscore(history, value)
     assert score > 0


### PR DESCRIPTION
## Summary
- exercise edge cases for percentile and percentile_zscore

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d6189578083269eb474cab1454ad6