### PR TITLE
Add FinanceAdvisor anomaly detection tests

### DIFF
--- a/tests/test_finance_advisor.py
+++ b/tests/test_finance_advisor.py
@@ -2,10 +2,21 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from agents.finance_advisor import percentile, percentile_zscore
+from agents.finance_advisor import FinanceAdvisor, percentile, percentile_zscore
 import pytest
+
+
+@pytest.fixture()
+def advisor() -> FinanceAdvisor:
+    with patch("agents.sdk.base.KafkaConsumer"), \
+         patch("agents.sdk.base.KafkaProducer"), \
+         patch("agents.sdk.base.start_http_server"):
+        agent = FinanceAdvisor()
+    agent.emit = MagicMock()
+    return agent
 
 
 def test_percentile() -> None:
@@ -41,3 +52,31 @@ def test_percentile_zscore_negative_numbers() -> None:
     value = -5
     score = percentile_zscore(history, value)
     assert score > 0
+
+
+def test_emit_on_high_zscore(advisor: FinanceAdvisor) -> None:
+    normal = [100, 105, 95, 100, 102, 98, 101, 99, 103, 97]
+    for amt in normal:
+        advisor.handle_event({"amount": amt})
+    advisor.emit.assert_not_called()
+
+    advisor.handle_event({"amount": 1000})
+    advisor.emit.assert_called_once()
+    topic, payload = advisor.emit.call_args[0]
+    assert topic == "ume.events.transaction.anomaly"
+    assert payload["amount"] == 1000
+    assert payload["z"] > 3
+
+
+def test_emit_on_low_zscore(advisor: FinanceAdvisor) -> None:
+    normal = [100, 105, 95, 100, 102, 98, 101, 99, 103, 97]
+    for amt in normal:
+        advisor.handle_event({"amount": amt})
+    advisor.emit.assert_not_called()
+
+    advisor.handle_event({"amount": -1000})
+    advisor.emit.assert_called_once()
+    topic, payload = advisor.emit.call_args[0]
+    assert topic == "ume.events.transaction.anomaly"
+    assert payload["amount"] == -1000
+    assert payload["z"] < -3


### PR DESCRIPTION
## Summary
- add FinanceAdvisor tests verifying emit on high or low z-score
- mock Kafka and metrics components for isolated testing

## Testing
- `ruff check agents tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e4d35a1088326b8aa2b029fcbee53