### PR TITLE
Refactor FinRL strategist to BaseAgent

### DIFF
--- a/agents/finrl_strategist/__main__.py
+++ b/agents/finrl_strategist/__main__.py
@@ -5,7 +5,7 @@ import asyncio
 import os
 from pathlib import Path
 
-from . import main as run_main
+from . import main
 from ..config import Config
 
 
@@ -19,12 +19,12 @@ def cli() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
+def entrypoint() -> None:
     args = cli()
     cfg_path = Path(args.config)
     cfg = Config(cfg_path) if cfg_path.exists() else None
-    asyncio.run(run_main(cfg))
+    asyncio.run(main(cfg))
 
 
 if __name__ == "__main__":
-    main()
+    entrypoint()

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -43,9 +43,22 @@ def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_finrl_strategist_entrypoint() -> None:
+def test_finrl_strategist_entrypoint(tmp_path: Path) -> None:
+    (tmp_path / "kafka").mkdir()
+    (tmp_path / "kafka" / "__init__.py").write_text(
+        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\n" "class KafkaProducer:\n    def __init__(self,*a,**k):\n        pass\n    def send(self,*a,**k):\n        pass\n    def flush(self):\n        pass\n    def close(self):\n        pass\n"
+    )
+    (tmp_path / "prometheus_client").mkdir()
+    (tmp_path / "prometheus_client" / "__init__.py").write_text(
+        "def start_http_server(*a, **k):\n    pass\nclass Counter:\n    def __init__(self,*a,**k):\n        pass\n    def labels(self, **k):\n        class L:\n            def inc(self,*a,**k):\n                pass\n        return L()\nclass Histogram:\n    def __init__(self,*a,**k):\n        pass\n    def labels(self, **k):\n        class L:\n            def observe(self,*a,**k):\n                pass\n        return L()\n"
+    )
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])
     result = subprocess.run(
         [sys.executable, "-m", "agents.finrl_strategist"],
+        cwd=tmp_path,
+        env=env,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary
- refactor FinRL strategist to subclass BaseAgent and handle schedule/trigger events
- update entrypoint to run the new agent
- adapt tests for new behavior and entrypoint dependencies

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4d34767c8326b4f43e3b5ec2214a