### PR TITLE
Add UME permission checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ CONFIG_PATH=/srv/agents.toml python -m agents.crypto_bot
 ```
 
 
+## UME Permissions
+
+The SDK communicates with the Unified Messaging Engine (UME) for permission
+checks.  Use `agents.sdk.check_permission` to verify whether a user may perform
+an action.  The function posts to the endpoint defined by the
+`UME_PERMISSION_ENDPOINT` environment variable, defaulting to
+`http://localhost:8000/permissions/check`.
+
+Requests are routed through the optional OPA sidecar in the same manner as
+`agents.sdk.ume_query`.  When `OPA_SIDECAR_URL` is set, the original endpoint
+and payload are wrapped and sent to the sidecar URL instead of directly to the
+UME service.
+
+
 ## FinRL Strategist
 
 The package `agents.finrl_strategist` integrates the [FinRL](https://github.com/AI4Finance-Foundation/FinRL) framework.

--- a/agents/sdk/__init__.py
+++ b/agents/sdk/__init__.py
@@ -62,4 +62,24 @@ def ume_query(endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
     return response.json()
 
 
-__all__ = ["emit_event", "ume_query", "BaseAgent"]
+def check_permission(user_id: str, action: str, group_id: str | None = None) -> bool:
+    """Return whether a user is allowed to perform an action.
+
+    The permission service is queried via :func:`ume_query`.  The endpoint is
+    taken from the ``UME_PERMISSION_ENDPOINT`` environment variable and
+    defaults to ``"http://localhost:8000/permissions/check"``.  When the
+    ``OPA_SIDECAR_URL`` variable is set, requests are routed through that
+    sidecar as described in :func:`ume_query`.
+    """
+
+    endpoint = os.getenv(
+        "UME_PERMISSION_ENDPOINT", "http://localhost:8000/permissions/check"
+    )
+    payload: dict[str, Any] = {"user_id": user_id, "action": action}
+    if group_id is not None:
+        payload["group_id"] = group_id
+    response = ume_query(endpoint, payload)
+    return bool(response.get("allow"))
+
+
+__all__ = ["emit_event", "ume_query", "check_permission", "BaseAgent"]

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -67,6 +67,20 @@ def test_ume_query_sidecar_env(monkeypatch):
         )
 
 
+def test_check_permission_allowed():
+    with patch("agents.sdk.ume_query") as mock_query:
+        mock_query.return_value = {"allow": True}
+        assert sdk.check_permission("user1", "read") is True
+        mock_query.assert_called_once()
+
+
+def test_check_permission_denied():
+    with patch("agents.sdk.ume_query") as mock_query:
+        mock_query.return_value = {"allow": False}
+        assert sdk.check_permission("user1", "write", group_id="g1") is False
+        mock_query.assert_called_once()
+
+
 def test_base_agent_dispatches_messages():
     with patch("agents.sdk.base.KafkaConsumer") as mock_consumer_cls, \
          patch("agents.sdk.base.KafkaProducer"), \


### PR DESCRIPTION
## Summary
- add `check_permission` helper that queries UME for action authorization
- document required UME endpoint and optional OPA sidecar routing
- test permission helper for allowed and denied responses

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8ab4eb2883269e690ff2505b7e1c