### PR TITLE
Require user identifiers for Kafka emissions

### DIFF
--- a/agents/crypto_bot/__init__.py
+++ b/agents/crypto_bot/__init__.py
@@ -76,7 +76,11 @@ class CryptoBot:
             # After execution publish basic metrics.
             positions = getattr(self.engine, "positions", [])
             profit = getattr(self.engine, "profit", 0.0)
-            emit_event("TradeSummary", {"positions": positions, "profit": profit})
+            emit_event(
+                "TradeSummary",
+                {"positions": positions, "profit": profit},
+                user_id="crypto_bot",
+            )
         finally:
             # Ensure the engine shuts down cleanly even if execution fails.
             shutdown = getattr(self.engine, "stop", None) or getattr(

--- a/agents/finrl_strategist/__init__.py
+++ b/agents/finrl_strategist/__init__.py
@@ -76,7 +76,7 @@ class FinRLStrategist(BaseAgent):
             for ticker, action in result.items():
                 topic = signals.get(action)
                 if topic:
-                    self.emit(topic, {"ticker": ticker})
+                    self.emit(topic, {"ticker": ticker}, user_id="finrl")
         self.producer.close()
         return result
 

--- a/agents/sdk/base.py
+++ b/agents/sdk/base.py
@@ -60,9 +60,26 @@ class BaseAgent:
             start_http_server(metrics_port)
             _METRICS_STARTED.add(metrics_port)
 
-    def emit(self, topic: str, event: dict[str, Any]) -> None:
-        """Emit an event to a Kafka topic."""
-        logger.debug("Emitting event to %s: %s", topic, event)
+    def emit(
+        self,
+        topic: str,
+        event: dict[str, Any],
+        *,
+        user_id: str,
+        group_id: str | None = None,
+    ) -> None:
+        """Emit an event to a Kafka topic.
+
+        The ``user_id`` is required; a ``ValueError`` is raised when it is
+        missing or falsy. ``group_id`` is accepted for future use.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+
+        if group_id is not None:  # pragma: no cover - reserved for future use
+            logger.debug("group_id provided: %s", group_id)
+
+        logger.debug("Emitting event to %s for user %s: %s", topic, user_id, event)
         self.producer.send(topic, event)
         self.producer.flush()
 

--- a/tests/test_crypto_bot.py
+++ b/tests/test_crypto_bot.py
@@ -68,6 +68,7 @@ def test_run_emits_metrics(tmp_path):
         emit.assert_called_once_with(
             "TradeSummary",
             {"positions": engine.positions, "profit": engine.profit},
+            user_id="crypto_bot",
         )
 
 
@@ -133,4 +134,5 @@ def test_run_emits_metrics_when_start_used(tmp_path):
         emit.assert_called_once_with(
             "TradeSummary",
             {"positions": engine.positions, "profit": engine.profit},
+            user_id="crypto_bot",
         )

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -20,8 +20,10 @@ def test_emit_event_uses_kafka_producer():
     with patch("agents.sdk.KafkaProducer") as mock_producer_cls:
         mock_producer = MagicMock()
         mock_producer_cls.return_value = mock_producer
-        sdk.emit_event("topic", {"a": 1})
-        mock_producer.send.assert_called_once()
+        sdk.emit_event("topic", {"a": 1}, user_id="u1")
+        mock_producer.send.assert_called_once_with(
+            "topic", {"a": 1, "user_id": "u1"}
+        )
         mock_producer.flush.assert_called_once()
         mock_producer.close.assert_called_once()
 
@@ -86,6 +88,22 @@ def test_base_agent_dispatches_messages():
         agent = TestAgent()
         agent.run()
         assert agent.events == [{"x": 1}]
+
+
+def test_emit_event_without_user_id_raises():
+    with patch("agents.sdk.KafkaProducer") as mock_prod:
+        with pytest.raises(ValueError):
+            sdk.emit_event("topic", {"a": 1}, user_id="")
+    mock_prod.assert_not_called()
+
+
+def test_base_agent_emit_without_user_id_raises():
+    with patch("agents.sdk.base.KafkaConsumer"), patch(
+        "agents.sdk.base.KafkaProducer"
+    ), patch("agents.sdk.base.start_http_server"):
+        agent = sdk.BaseAgent("topic", metrics_port=None)
+        with pytest.raises(ValueError):
+            agent.emit("topic", {"a": 1}, user_id="")
 
 
 def test_metrics_increment_when_processing_events():


### PR DESCRIPTION
## Summary
- require user_id (and optional group_id) when agents emit events
- add user_id forwarding to emit_event helper
- cover missing user_id in tests

## Testing
- `ruff check agents tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8ab4583083268f015b606a85abe6