### PR TITLE
Add explainability agent for finance analysis

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import requests
+
+from ..sdk import BaseAgent
+from ..config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class ExplainabilityAgent(BaseAgent):
+    """Agent that provides explanations for finance analyses."""
+
+    topic_subscriptions = ["finance.explain.request"]
+
+    def __init__(
+        self,
+        engine_url: str,
+        *,
+        bootstrap_servers: str = "localhost:9092",
+    ) -> None:
+        super().__init__(
+            self.topic_subscriptions,
+            bootstrap_servers=bootstrap_servers,
+            group_id="explainability-agent",
+        )
+        self.engine_url = engine_url.rstrip("/")
+
+    def handle_event(self, event: dict[str, Any]) -> None:  # type: ignore[override]
+        analysis_id = event.get("analysis_id")
+        user_id = event.get("user_id")
+        if not analysis_id or not user_id:
+            logger.debug("Missing analysis_id or user_id: %s", event)
+            return
+        try:
+            resp = requests.get(
+                f"{self.engine_url}/analysis/{analysis_id}/actions", timeout=10
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to fetch actions: %s", exc)
+            return
+        actions = data.get("actions", [])
+        explanations = []
+        for action in actions:
+            name = action.get("name", "unknown")
+            pros = "; ".join(action.get("pros", []))
+            cons = "; ".join(action.get("cons", []))
+            explanations.append({"action": name, "pros": pros, "cons": cons})
+        payload = {"analysis_id": analysis_id, "explanations": explanations}
+        self.emit(
+            "finance.explain.result",
+            payload,
+            user_id=user_id,
+        )
+
+
+async def main(config: Config | None = None) -> None:
+    """Asynchronous entrypoint for the explainability agent."""
+    section = config.get("explainability_agent", {}) if config else {}
+    engine_url = section.get("engine_url", "http://localhost:8000")
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    agent = ExplainabilityAgent(engine_url, bootstrap_servers=bootstrap)
+    await asyncio.to_thread(agent.run)
+
+
+__all__ = ["ExplainabilityAgent", "main"]

--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.explainability_agent import ExplainabilityAgent
+
+
+@pytest.fixture()
+def agent() -> ExplainabilityAgent:
+    with patch("agents.sdk.base.KafkaConsumer"), \
+         patch("agents.sdk.base.KafkaProducer"), \
+         patch("agents.sdk.base.start_http_server"):
+        ag = ExplainabilityAgent("http://engine")
+    ag.emit = MagicMock()
+    return ag
+
+
+def test_explainability_agent_emits(agent: ExplainabilityAgent) -> None:
+    event = {"analysis_id": "123", "user_id": "user1"}
+    response = {
+        "actions": [
+            {"name": "invest", "pros": ["growth"], "cons": ["risk"]}
+        ]
+    }
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response
+    mock_resp.raise_for_status.return_value = None
+    with patch("agents.explainability_agent.requests.get", return_value=mock_resp) as mock_get:
+        agent.handle_event(event)
+    mock_get.assert_called_once_with("http://engine/analysis/123/actions", timeout=10)
+    agent.emit.assert_called_once()
+    topic, payload = agent.emit.call_args[0]
+    kwargs = agent.emit.call_args.kwargs
+    assert topic == "finance.explain.result"
+    assert payload["analysis_id"] == "123"
+    assert payload["explanations"][0]["action"] == "invest"
+    assert kwargs["user_id"] == "user1"
+
+
+def test_explainability_agent_missing_analysis_id(agent: ExplainabilityAgent) -> None:
+    event = {"user_id": "user1"}
+    with patch("agents.explainability_agent.requests.get") as mock_get:
+        agent.handle_event(event)
+    mock_get.assert_not_called()
+    agent.emit.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `ExplainabilityAgent` to fetch proposed actions from finance-engine and emit pros/cons explanations
- Provide async `main` entrypoint and configuration for the explainability agent
- Test explainability agent with mocked finance-engine responses

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9382059c8326b671ddf402af8d7f