### PR TITLE
Add Plaid transaction sync agent

### DIFF
--- a/agents/plaid_sync/__init__.py
+++ b/agents/plaid_sync/__init__.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from ..sdk import BaseAgent, check_permission
+from ..config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class PlaidClient:
+    """Minimal Plaid client placeholder used for transaction sync."""
+
+    def __init__(self, client_id: str, client_secret: str) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def fetch_transactions(self, user_id: str) -> list[dict[str, Any]]:
+        """Return a list of transactions for ``user_id``.
+
+        This is a stub implementation. Real implementations should call the
+        Plaid API and return transaction dictionaries.
+        """
+
+        return []
+
+
+class PlaidSync(BaseAgent):
+    """Agent that syncs transactions from Plaid and emits events."""
+
+    topic_subscriptions = ["plaid.transactions.sync"]
+
+    def __init__(
+        self,
+        plaid_client: PlaidClient,
+        *,
+        bootstrap_servers: str = "localhost:9092",
+    ) -> None:
+        super().__init__(
+            self.topic_subscriptions,
+            bootstrap_servers=bootstrap_servers,
+            group_id="plaid-sync",
+        )
+        self.plaid = plaid_client
+        self.bootstrap_servers = bootstrap_servers
+
+    def sync(self, user_id: str, group_id: str | None = None) -> list[dict[str, Any]]:
+        """Fetch transactions and emit ``plaid.transaction.synced`` events."""
+
+        if not check_permission(user_id, "read", group_id):
+            logger.info("Read permission denied for %s", user_id)
+            return []
+        transactions = self.plaid.fetch_transactions(user_id)
+        if not check_permission(user_id, "write", group_id):
+            logger.info("Write permission denied for %s", user_id)
+            return transactions
+        for tx in transactions:
+            payload = tx.copy()
+            payload["user_id"] = user_id
+            if group_id is not None:
+                payload["group_id"] = group_id
+            self.emit(
+                "plaid.transaction.synced",
+                payload,
+                user_id=user_id,
+                group_id=group_id,
+            )
+        return transactions
+
+    def handle_event(self, event: dict[str, Any]) -> None:  # type: ignore[override]
+        user_id = event.get("user_id")
+        group_id = event.get("group_id")
+        if not user_id:
+            logger.debug("Event missing user_id: %s", event)
+            return
+        self.sync(user_id, group_id)
+
+
+async def main(config: Config | None = None) -> None:
+    """Entry point for running ``PlaidSync`` asynchronously."""
+
+    section = config.get("plaid_sync", {}) if config else {}
+    client_id = section.get("client_id", "")
+    client_secret = section.get("client_secret", "")
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    plaid_client = PlaidClient(client_id, client_secret)
+    agent = PlaidSync(plaid_client, bootstrap_servers=bootstrap)
+    await asyncio.to_thread(agent.run)
+
+
+__all__ = ["PlaidClient", "PlaidSync", "main"]

--- a/agents/plaid_sync/__main__.py
+++ b/agents/plaid_sync/__main__.py
@@ -1,0 +1,23 @@
+from . import main
+import argparse
+import asyncio
+import os
+from pathlib import Path
+from ..config import Config
+
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(main(cfg))

--- a/tests/test_plaid_sync.py
+++ b/tests/test_plaid_sync.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from agents.plaid_sync import PlaidSync, PlaidClient  # noqa: E402
+
+
+@pytest.fixture()
+def agent() -> PlaidSync:
+    plaid = MagicMock(spec=PlaidClient)
+    with patch("agents.sdk.base.KafkaConsumer"),          patch("agents.sdk.base.KafkaProducer"),          patch("agents.sdk.base.start_http_server"):
+        ag = PlaidSync(plaid)
+    ag.emit = MagicMock()
+    ag.plaid = plaid
+    return ag
+
+
+def test_permission_checks_and_event_emission(agent: PlaidSync) -> None:
+    agent.plaid.fetch_transactions.return_value = [{"id": "t1"}]
+    with patch("agents.plaid_sync.check_permission", side_effect=[True, True]) as cp:
+        agent.sync("u1", group_id="g1")
+    assert cp.call_args_list == [
+        (("u1", "read", "g1"),),
+        (("u1", "write", "g1"),),
+    ]
+    agent.plaid.fetch_transactions.assert_called_once_with("u1")
+    agent.emit.assert_called_once()
+    topic, payload = agent.emit.call_args[0]
+    kwargs = agent.emit.call_args[1]
+    assert topic == "plaid.transaction.synced"
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["group_id"] == "g1"
+    assert payload["user_id"] == "u1"
+    assert payload["group_id"] == "g1"
+
+
+def test_permission_denied(agent: PlaidSync) -> None:
+    with patch("agents.plaid_sync.check_permission", return_value=False) as cp:
+        agent.sync("u1")
+    cp.assert_called_once_with("u1", "read", None)
+    agent.plaid.fetch_transactions.assert_not_called()
+    agent.emit.assert_not_called()
+
+
+def test_write_permission_denied(agent: PlaidSync) -> None:
+    agent.plaid.fetch_transactions.return_value = [{"id": "t1"}]
+    with patch("agents.plaid_sync.check_permission", side_effect=[True, False]) as cp:
+        agent.sync("u1")
+    assert cp.call_args_list == [
+        (("u1", "read", None),),
+        (("u1", "write", None),),
+    ]
+    agent.emit.assert_not_called()


### PR DESCRIPTION
## Summary
- add PlaidSync agent to synchronize Plaid transactions
- ensure permission checks before reading/writing and emit `plaid.transaction.synced`
- provide config-driven async entry point
- add tests for permission and event handling

## Testing
- `ruff check agents/plaid_sync/__init__.py tests/test_plaid_sync.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9382925c832698f7e72e0885620d