### PR TITLE
Add permission checks to FinanceAdvisor events

### DIFF
--- a/tests/test_finance_advisor_entrypoint.py
+++ b/tests/test_finance_advisor_entrypoint.py
@@ -23,7 +23,7 @@ def test_finance_advisor_entrypoint(tmp_path: Path) -> None:
         "            raise StopIteration\n"
         "        self._sent = True\n"
         "        print('event consumed', flush=True)\n"
-        "        return DummyMessage({'amount': 1})\n"
+        "        return DummyMessage({'amount': 1, 'user_id': 'u1'})\n"
         "\n"
         "class KafkaProducer:\n"
         "    def __init__(self, *args, **kwargs):\n"
@@ -32,6 +32,17 @@ def test_finance_advisor_entrypoint(tmp_path: Path) -> None:
         "        pass\n"
         "    def flush(self):\n"
         "        pass\n"
+    )
+
+    (tmp_path / "requests").mkdir()
+    (tmp_path / "requests" / "__init__.py").write_text(
+        "class Response:\n"
+        "    def raise_for_status(self):\n"
+        "        pass\n"
+        "    def json(self):\n"
+        "        return {'allow': True}\n"
+        "def post(*args, **kwargs):\n"
+        "    return Response()\n"
     )
 
     (tmp_path / "prometheus_client").mkdir()


### PR DESCRIPTION
## Summary
- validate transaction events include a user id and check permissions before processing
- attach user and group identifiers to emitted anomaly events
- update FinanceAdvisor tests to provide identifiers and mock permission results

## Testing
- `ruff check agents/finance_advisor/__init__.py tests/test_finance_advisor.py tests/test_finance_advisor_entrypoint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e9784059883268abb2b1d7b010544