### PR TITLE
Include user and group in BaseAgent payload

### DIFF
--- a/agents/sdk/base.py
+++ b/agents/sdk/base.py
@@ -71,16 +71,18 @@ class BaseAgent:
         """Emit an event to a Kafka topic.
 
         The ``user_id`` is required; a ``ValueError`` is raised when it is
-        missing or falsy. ``group_id`` is accepted for future use.
+        missing or falsy. When provided, ``group_id`` is added to the payload.
         """
         if not user_id:
             raise ValueError("user_id is required")
 
-        if group_id is not None:  # pragma: no cover - reserved for future use
-            logger.debug("group_id provided: %s", group_id)
+        payload = event.copy()
+        payload["user_id"] = user_id
+        if group_id is not None:
+            payload["group_id"] = group_id
 
-        logger.debug("Emitting event to %s for user %s: %s", topic, user_id, event)
-        self.producer.send(topic, event)
+        logger.debug("Emitting event to %s for user %s: %s", topic, user_id, payload)
+        self.producer.send(topic, payload)
         self.producer.flush()
 
     def dispatch(self, event: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- ensure BaseAgent.emit injects user_id and optional group_id into a copied event payload
- test that SDK emit_event and BaseAgent.emit send payloads containing user and group identifiers

## Testing
- `ruff check agents/sdk/base.py tests/test_sdk.py`
- `PYTHONPATH=. pytest tests/test_sdk.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd32c39fc8326895c13fe1db863fc