### PR TITLE
Enforce calendar creation permissions and propagate user id

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 import requests
 
-from ..sdk import BaseAgent
+from ..sdk import BaseAgent, check_permission
 from ..config import Config
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,9 @@ class CalendarNLPAgent(BaseAgent):
         if not text or not user_id:
             logger.debug("Invalid event: %s", event)
             return
+        if not check_permission(user_id, "calendar:create"):
+            logger.info("Permission denied for user %s", user_id)
+            return
         result = self.llm(text)
         calendar_event = {
             "title": result.get("title"),
@@ -46,6 +49,7 @@ class CalendarNLPAgent(BaseAgent):
             "description": result.get("description"),
             "is_all_day": result.get("is_all_day"),
             "recurrence": result.get("recurrence"),
+            "user_id": user_id,
         }
         self.emit(
             "calendar.event.create_request",


### PR DESCRIPTION
## Summary
- verify `calendar:create` permission before generating calendar events
- include `user_id` in calendar event payload
- test permission handling and emitted payload

## Testing
- `ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd32cca28832694cf792c7dd96b2f