### PR TITLE
Check write permission before anomaly emission

### DIFF
--- a/agents/finance_advisor/__init__.py
+++ b/agents/finance_advisor/__init__.py
@@ -71,6 +71,9 @@ class FinanceAdvisor(BaseAgent):
         score = percentile_zscore(self.amounts, float(amount))
         logger.info("Transaction %s has z-score %.2f", amount, score)
         if abs(score) > 3:
+            if not check_permission(user_id, "write", group_id):
+                logger.info("Write permission denied for user %s", user_id)
+                return
             payload = {"amount": amount, "z": score, "user_id": user_id}
             if group_id is not None:
                 payload["group_id"] = group_id

--- a/tests/test_finance_advisor.py
+++ b/tests/test_finance_advisor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from agents.finance_advisor import FinanceAdvisor, percentile, percentile_zscore
@@ -61,7 +61,8 @@ def test_emit_on_high_zscore(advisor: FinanceAdvisor) -> None:
             advisor.handle_event({"amount": amt, "user_id": "u1", "group_id": "g1"})
         advisor.emit.assert_not_called()
         advisor.handle_event({"amount": 1000, "user_id": "u1", "group_id": "g1"})
-    assert cp.call_count == len(normal) + 1
+    assert cp.call_count == len(normal) + 2
+    assert cp.call_args_list[-2:] == [call("u1", "read", "g1"), call("u1", "write", "g1")]
     advisor.emit.assert_called_once()
     topic, payload = advisor.emit.call_args[0]
     kwargs = advisor.emit.call_args[1]
@@ -81,7 +82,8 @@ def test_emit_on_low_zscore(advisor: FinanceAdvisor) -> None:
             advisor.handle_event({"amount": amt, "user_id": "u1"})
         advisor.emit.assert_not_called()
         advisor.handle_event({"amount": -1000, "user_id": "u1"})
-    assert cp.call_count == len(normal) + 1
+    assert cp.call_count == len(normal) + 2
+    assert cp.call_args_list[-2:] == [call("u1", "read", None), call("u1", "write", None)]
     advisor.emit.assert_called_once()
     topic, payload = advisor.emit.call_args[0]
     kwargs = advisor.emit.call_args[1]


### PR DESCRIPTION
## Summary
- ensure FinanceAdvisor verifies write permission before emitting anomalies
- test read and write permission checks on anomaly emission

## Testing
- `pytest tests/test_finance_advisor.py tests/test_finance_advisor_entrypoint.py`
- `ruff check agents/finance_advisor/__init__.py tests/test_finance_advisor.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6ccce408326bfd5d0e162d14820