### PR TITLE
feat: guard explainability actions with permission

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import requests
 
-from ..sdk import BaseAgent
+from ..sdk import BaseAgent, check_permission
 from ..config import Config
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,9 @@ class ExplainabilityAgent(BaseAgent):
         user_id = event.get("user_id")
         if not analysis_id or not user_id:
             logger.debug("Missing analysis_id or user_id: %s", event)
+            return
+        if not check_permission(user_id, "analysis:read"):
+            logger.info("Permission denied for user %s", user_id)
             return
         try:
             resp = requests.get(

--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -31,8 +31,10 @@ def test_explainability_agent_emits(agent: ExplainabilityAgent) -> None:
     mock_resp = MagicMock()
     mock_resp.json.return_value = response
     mock_resp.raise_for_status.return_value = None
-    with patch("agents.explainability_agent.requests.get", return_value=mock_resp) as mock_get:
+    with patch("agents.explainability_agent.requests.get", return_value=mock_resp) as mock_get, \
+         patch("agents.explainability_agent.check_permission", return_value=True) as mock_perm:
         agent.handle_event(event)
+    mock_perm.assert_called_once_with("user1", "analysis:read")
     mock_get.assert_called_once_with("http://engine/analysis/123/actions", timeout=10)
     agent.emit.assert_called_once()
     topic, payload = agent.emit.call_args[0]
@@ -63,18 +65,33 @@ def test_event_consumed_by_downstream() -> None:
     with patch("agents.sdk.base.KafkaConsumer"), \
          patch("agents.sdk.base.KafkaProducer", return_value=MockProducer()), \
          patch("agents.sdk.base.start_http_server"), \
-         patch("agents.explainability_agent.requests.get", return_value=mock_resp):
+         patch("agents.explainability_agent.requests.get", return_value=mock_resp), \
+         patch("agents.explainability_agent.check_permission", return_value=True):
         agent = ExplainabilityAgent("http://engine")
         agent.handle_event({"analysis_id": "123", "user_id": "u1"})
     downstream.assert_called_once()
     topic, payload = downstream.call_args[0]
     assert topic == "finance.explain.result"
     assert payload["analysis_id"] == "123"
+    assert payload["user_id"] == "u1"
 
 
 def test_explainability_agent_missing_analysis_id(agent: ExplainabilityAgent) -> None:
     event = {"user_id": "user1"}
-    with patch("agents.explainability_agent.requests.get") as mock_get:
+    with patch("agents.explainability_agent.requests.get") as mock_get, \
+         patch("agents.explainability_agent.check_permission") as mock_perm:
         agent.handle_event(event)
+    mock_perm.assert_not_called()
     mock_get.assert_not_called()
     agent.emit.assert_not_called()
+
+
+def test_permission_denied(agent: ExplainabilityAgent) -> None:
+    event = {"analysis_id": "123", "user_id": "user1"}
+    with patch("agents.explainability_agent.check_permission", return_value=False) as mock_perm, \
+         patch("agents.explainability_agent.requests.get") as mock_get:
+        agent.handle_event(event)
+    mock_perm.assert_called_once_with("user1", "analysis:read")
+    mock_get.assert_not_called()
+    agent.emit.assert_not_called()
+


### PR DESCRIPTION
## Summary
- ensure ExplainabilityAgent checks `analysis:read` permission before fetching actions
- include `user_id` when emitting explain result events
- test permission checks and user id injection

## Testing
- `ruff check agents/explainability_agent/__init__.py tests/test_explainability_agent.py`
- `pytest tests/test_explainability_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6cbaec8832699946ec4b3ae6b88