### PR TITLE
Support group_id in CalendarNLP agent

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -34,10 +34,11 @@ class CalendarNLPAgent(BaseAgent):
         """Handle a natural language calendar request."""
         text = event.get("text")
         user_id = event.get("user_id")
+        group_id = event.get("group_id")
         if not text or not user_id:
             logger.debug("Invalid event: %s", event)
             return
-        if not check_permission(user_id, "calendar:create"):
+        if not check_permission(user_id, "calendar:create", group_id):
             logger.info("Permission denied for user %s", user_id)
             return
         result = self.llm(text)
@@ -49,12 +50,12 @@ class CalendarNLPAgent(BaseAgent):
             "description": result.get("description"),
             "is_all_day": result.get("is_all_day"),
             "recurrence": result.get("recurrence"),
-            "user_id": user_id,
         }
         self.emit(
             "calendar.event.create_request",
-            calendar_event,
+            {"event": calendar_event},
             user_id=user_id,
+            group_id=group_id,
         )
         logger.info("Emitted calendar event for user %s", user_id)
 

--- a/tests/test_calendar_nlp.py
+++ b/tests/test_calendar_nlp.py
@@ -24,7 +24,7 @@ def agent() -> tuple[CalendarNLPAgent, MagicMock]:
          patch("agents.sdk.base.KafkaProducer"), \
          patch("agents.sdk.base.start_http_server"):
         agent = CalendarNLPAgent(llm)
-    agent.emit = MagicMock()
+    agent.emit = MagicMock(wraps=agent.emit)
     return agent, llm
 
 
@@ -33,15 +33,35 @@ def test_parses_and_emits_event(agent: tuple[CalendarNLPAgent, MagicMock]) -> No
     event = {"user_id": "u1", "text": "Lunch with Sam at noon"}
     with patch("agents.calendar_nlp.check_permission", return_value=True) as mock_perm:
         agent_instance.handle_event(event)
-    mock_perm.assert_called_once_with("u1", "calendar:create")
+    mock_perm.assert_called_once_with("u1", "calendar:create", None)
     llm.assert_called_once_with("Lunch with Sam at noon")
     agent_instance.emit.assert_called_once()
-    topic, payload = agent_instance.emit.call_args[0]
+    topic, payload = agent_instance.producer.send.call_args[0]
     kwargs = agent_instance.emit.call_args[1]
     assert topic == "calendar.event.create_request"
-    assert payload["title"] == "Lunch"
+    assert payload["event"]["title"] == "Lunch"
     assert payload["user_id"] == "u1"
+    assert "group_id" not in payload
     assert kwargs["user_id"] == "u1"
+    assert kwargs["group_id"] is None
+
+
+def test_parses_and_emits_event_with_group(agent: tuple[CalendarNLPAgent, MagicMock]) -> None:
+    agent_instance, llm = agent
+    event = {"user_id": "u1", "text": "Lunch with Sam at noon", "group_id": "g1"}
+    with patch("agents.calendar_nlp.check_permission", return_value=True) as mock_perm:
+        agent_instance.handle_event(event)
+    mock_perm.assert_called_once_with("u1", "calendar:create", "g1")
+    llm.assert_called_once_with("Lunch with Sam at noon")
+    agent_instance.emit.assert_called_once()
+    topic, payload = agent_instance.producer.send.call_args[0]
+    kwargs = agent_instance.emit.call_args[1]
+    assert topic == "calendar.event.create_request"
+    assert payload["event"]["title"] == "Lunch"
+    assert payload["user_id"] == "u1"
+    assert payload["group_id"] == "g1"
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["group_id"] == "g1"
 
 
 def test_emitted_event_consumed_by_downstream() -> None:
@@ -68,8 +88,9 @@ def test_emitted_event_consumed_by_downstream() -> None:
     downstream.assert_called_once()
     topic, payload = downstream.call_args[0]
     assert topic == "calendar.event.create_request"
-    assert payload["title"] == "Lunch"
+    assert payload["event"]["title"] == "Lunch"
     assert payload["user_id"] == "u1"
+    assert "group_id" not in payload
 
 
 def test_missing_fields(agent: tuple[CalendarNLPAgent, MagicMock]) -> None:
@@ -85,6 +106,6 @@ def test_permission_denied(agent: tuple[CalendarNLPAgent, MagicMock]) -> None:
     agent_instance, llm = agent
     with patch("agents.calendar_nlp.check_permission", return_value=False) as mock_perm:
         agent_instance.handle_event({"user_id": "u1", "text": "Lunch"})
-    mock_perm.assert_called_once_with("u1", "calendar:create")
+    mock_perm.assert_called_once_with("u1", "calendar:create", None)
     llm.assert_not_called()
     agent_instance.emit.assert_not_called()


### PR DESCRIPTION
## Summary
- update CalendarNLPAgent to forward optional group_id and emit nested event payloads
- extend calendar NLP tests to assert user and group metadata and add group_id case

## Testing
- `ruff check tests/test_calendar_nlp.py agents/calendar_nlp/__init__.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68915047ba4083268f6c5d19426585fa