### PR TITLE
Add group ID propagation test for ExplainabilityAgent

### DIFF
--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -76,6 +76,39 @@ def test_event_consumed_by_downstream() -> None:
     assert payload["user_id"] == "u1"
 
 
+def test_group_id_propagates() -> None:
+    downstream = MagicMock()
+
+    class MockProducer:
+        def send(self, topic, event):  # type: ignore[no-untyped-def]
+            downstream(topic, event)
+
+        def flush(self):  # type: ignore[no-untyped-def]
+            pass
+
+    response = {
+        "actions": [{"name": "invest", "pros": ["growth"], "cons": ["risk"]}]
+    }
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response
+    mock_resp.raise_for_status.return_value = None
+
+    with patch("agents.sdk.base.KafkaConsumer"), \
+         patch("agents.sdk.base.KafkaProducer", return_value=MockProducer()), \
+         patch("agents.sdk.base.start_http_server"), \
+         patch("agents.explainability_agent.requests.get", return_value=mock_resp), \
+         patch("agents.explainability_agent.check_permission", return_value=True) as mock_perm:
+        agent = ExplainabilityAgent("http://engine")
+        agent.handle_event({"analysis_id": "123", "user_id": "u1", "group_id": "g1"})
+    mock_perm.assert_called_once_with("u1", "analysis:read", "g1")
+    downstream.assert_called_once()
+    topic, payload = downstream.call_args[0]
+    assert topic == "finance.explain.result"
+    assert payload["analysis_id"] == "123"
+    assert payload["user_id"] == "u1"
+    assert payload["group_id"] == "g1"
+
+
 def test_explainability_agent_missing_analysis_id(agent: ExplainabilityAgent) -> None:
     event = {"user_id": "user1"}
     with patch("agents.explainability_agent.requests.get") as mock_get, \


### PR DESCRIPTION
## Summary
- test that ExplainabilityAgent forwards group_id to permission check and emitted payload

## Testing
- `ruff check tests/test_explainability_agent.py`
- `pytest tests/test_explainability_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6894b8f3f4a48326bb29c459d17c2cb0