### PR TITLE
Remove manual user/group from anomaly payload

### DIFF
--- a/agents/finance_advisor/__init__.py
+++ b/agents/finance_advisor/__init__.py
@@ -74,9 +74,7 @@ class FinanceAdvisor(BaseAgent):
             if not check_permission(user_id, "write", group_id):
                 logger.info("Write permission denied for user %s", user_id)
                 return
-            payload = {"amount": amount, "z": score, "user_id": user_id}
-            if group_id is not None:
-                payload["group_id"] = group_id
+            payload = {"amount": amount, "z": score}
             self.emit(
                 "ume.events.transaction.anomaly",
                 payload,


### PR DESCRIPTION
## Summary
- Rely on `BaseAgent.emit` to attach `user_id` and `group_id` for finance advisor anomalies
- Verify anomalies defer user and group assignment to `BaseAgent.emit`

## Testing
- `ruff check agents/finance_advisor/__init__.py tests/test_finance_advisor.py`
- `pytest tests/test_finance_advisor.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cbe2efe08326a6b097eb0b00c703