### PR TITLE
Remove redundant user and group IDs from Plaid sync payload

### DIFF
--- a/agents/plaid_sync/__init__.py
+++ b/agents/plaid_sync/__init__.py
@@ -58,9 +58,6 @@ class PlaidSync(BaseAgent):
             return transactions
         for tx in transactions:
             payload = tx.copy()
-            payload["user_id"] = user_id
-            if group_id is not None:
-                payload["group_id"] = group_id
             self.emit(
                 "plaid.transaction.synced",
                 payload,

--- a/tests/test_plaid_sync.py
+++ b/tests/test_plaid_sync.py
@@ -35,8 +35,8 @@ def test_permission_checks_and_event_emission(agent: PlaidSync) -> None:
     assert topic == "plaid.transaction.synced"
     assert kwargs["user_id"] == "u1"
     assert kwargs["group_id"] == "g1"
-    assert payload["user_id"] == "u1"
-    assert payload["group_id"] == "g1"
+    assert "user_id" not in payload
+    assert "group_id" not in payload
 
 
 def test_permission_denied(agent: PlaidSync) -> None:


### PR DESCRIPTION
## Summary
- Stop injecting `user_id` and `group_id` into Plaid transaction payloads
- Update PlaidSync tests to ensure emitted events still include `user_id` and `group_id` via kwargs

## Testing
- `ruff check agents/plaid_sync/__init__.py tests/test_plaid_sync.py`
- `pytest tests/test_plaid_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cbc328a48326b3ba48581eb1a24b