### PR TITLE
Handle invalid timezones in CalendarNLPAgent

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from datetime import datetime
 from typing import Any, Callable
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 
@@ -45,7 +45,14 @@ class CalendarNLPAgent(BaseAgent):
         if not check_permission(user_id, "calendar:create", group_id):
             logger.info("Permission denied for user %s", user_id)
             return
-        now = datetime.now(ZoneInfo(timezone)) if timezone else datetime.utcnow()
+        if timezone:
+            try:
+                now = datetime.now(ZoneInfo(timezone))
+            except ZoneInfoNotFoundError:
+                logger.exception("Failed to find timezone %s", timezone)
+                return
+        else:
+            now = datetime.utcnow()
         payload = {
             "text": text,
             "current_date": now.date().isoformat(),

--- a/tests/test_calendar_nlp.py
+++ b/tests/test_calendar_nlp.py
@@ -107,6 +107,15 @@ def test_parses_event_with_group_and_timezone(agent: tuple[CalendarNLPAgent, Mag
     assert kwargs["group_id"] == "g1"
 
 
+def test_invalid_timezone(agent: tuple[CalendarNLPAgent, MagicMock]) -> None:
+    agent_instance, llm = agent
+    event = {"user_id": "u1", "text": "Lunch", "timezone": "Invalid/Zone"}
+    with patch("agents.calendar_nlp.check_permission", return_value=True):
+        agent_instance.handle_event(event)
+    llm.assert_not_called()
+    agent_instance.emit.assert_not_called()
+
+
 def test_emitted_event_consumed_by_downstream() -> None:
     """Integration-style test verifying downstream consumption of events."""
 


### PR DESCRIPTION
## Summary
- handle unknown timezones gracefully in CalendarNLPAgent
- test CalendarNLPAgent with invalid timezone

## Testing
- `ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py`
- `pytest tests/test_calendar_nlp.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cbc2670c8326874ebee564c7ab68