### PR TITLE
Cap FinanceAdvisor history to recent transactions

### DIFF
--- a/tests/test_finance_advisor.py
+++ b/tests/test_finance_advisor.py
@@ -119,3 +119,13 @@ def test_permission_denied(advisor: tuple[FinanceAdvisor, MagicMock]) -> None:
         agent.handle_event({"amount": 10, "user_id": "u1"})
     cp.assert_called_once_with("u1", "read", None)
     agent.emit.assert_not_called()
+
+
+def test_history_cap(advisor: tuple[FinanceAdvisor, MagicMock]) -> None:
+    agent, _ = advisor
+    with patch("agents.finance_advisor.check_permission", return_value=True):
+        total = FinanceAdvisor.HISTORY_SIZE + 100
+        for i in range(total):
+            agent.handle_event({"amount": i, "user_id": "u1"})
+    assert len(agent.amounts) == FinanceAdvisor.HISTORY_SIZE
+    assert agent.amounts[0] == total - FinanceAdvisor.HISTORY_SIZE


### PR DESCRIPTION
## Summary
- limit `FinanceAdvisor` to remember only the last 1000 transaction amounts using a deque
- compute anomaly scores before recording new amounts
- add test ensuring transaction history is capped

## Testing
- `ruff check agents/finance_advisor/__init__.py tests/test_finance_advisor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964d1a5af083268c2689622c2bb3b6