### PR TITLE
Use full datetime in calendar NLP payload

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -55,7 +55,7 @@ class CalendarNLPAgent(BaseAgent):
             now = datetime.utcnow()
         payload = {
             "text": text,
-            "current_date": now.date().isoformat(),
+            "current_datetime": now.isoformat(),
             "timezone": timezone,
         }
         result = self.llm(payload)

--- a/tests/test_calendar_nlp.py
+++ b/tests/test_calendar_nlp.py
@@ -38,7 +38,7 @@ def test_parses_and_emits_event(agent: tuple[CalendarNLPAgent, MagicMock]) -> No
 
     llm.assert_called_once_with({
         "text": "Lunch with Sam at noon",
-        "current_date": ANY,
+        "current_datetime": ANY,
         "timezone": None,
     })
     agent_instance.emit.assert_called_once()
@@ -65,7 +65,7 @@ def test_parses_and_emits_event_with_group(agent: tuple[CalendarNLPAgent, MagicM
     mock_perm.assert_called_once_with("u1", "calendar:create", "g1")
     llm.assert_called_once_with({
         "text": "Lunch with Sam at noon",
-        "current_date": ANY,
+        "current_datetime": ANY,
         "timezone": "UTC",
     })
     agent_instance.emit.assert_called_once()
@@ -93,7 +93,7 @@ def test_parses_event_with_group_and_timezone(agent: tuple[CalendarNLPAgent, Mag
     mock_perm.assert_called_once_with("u1", "calendar:create", "g1")
     llm.assert_called_once_with({
         "text": "Lunch with Sam at noon",
-        "current_date": ANY,
+        "current_datetime": ANY,
         "timezone": "America/New_York",
     })
     agent_instance.emit.assert_called_once()


### PR DESCRIPTION
## Summary
- send `current_datetime` ISO string in CalendarNLPAgent payload
- align calendar NLP tests with new `current_datetime` field

## Testing
- `ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896549270148326906c3d3854c3d56f