### PR TITLE
Return empty list when write permission denied in Plaid sync

### DIFF
--- a/agents/crypto_bot/__main__.py
+++ b/agents/crypto_bot/__main__.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 from pathlib import Path
 
-from . import CryptoBot
 from ..config import Config
 
 

--- a/agents/plaid_sync/__init__.py
+++ b/agents/plaid_sync/__init__.py
@@ -55,7 +55,7 @@ class PlaidSync(BaseAgent):
         transactions = self.plaid.fetch_transactions(user_id)
         if not check_permission(user_id, "write", group_id):
             logger.info("Write permission denied for %s", user_id)
-            return transactions
+            return []
         for tx in transactions:
             payload = tx.copy()
             self.emit(

--- a/tests/test_plaid_sync.py
+++ b/tests/test_plaid_sync.py
@@ -50,9 +50,10 @@ def test_permission_denied(agent: PlaidSync) -> None:
 def test_write_permission_denied(agent: PlaidSync) -> None:
     agent.plaid.fetch_transactions.return_value = [{"id": "t1"}]
     with patch("agents.plaid_sync.check_permission", side_effect=[True, False]) as cp:
-        agent.sync("u1")
+        result = agent.sync("u1")
     assert cp.call_args_list == [
         (("u1", "read", None),),
         (("u1", "write", None),),
     ]
     agent.emit.assert_not_called()
+    assert result == []


### PR DESCRIPTION
## Summary
- return an empty list and log when Plaid sync lacks write permission
- test that no transactions are returned when write access is denied
- drop unused CryptoBot import so ruff passes

## Testing
- `ruff check agents/plaid_sync/__init__.py tests/test_plaid_sync.py agents/crypto_bot/__main__.py`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896bc02d1bc832695410a4896ccbc82