### PR TITLE
Raise explicit error when kafka dependency missing

### DIFF
--- a/agents/sdk/__init__.py
+++ b/agents/sdk/__init__.py
@@ -40,6 +40,9 @@ def emit_event(
     optional and, if provided, included in the payload.
     """
     payload = _inject_identifiers(event, user_id=user_id, group_id=group_id)
+    if KafkaProducer is None:  # pragma: no cover - dependency missing
+        msg = "kafka-python library is required to emit events"
+        raise RuntimeError(msg)
     producer = KafkaProducer(
         bootstrap_servers=bootstrap_servers,
         value_serializer=lambda v: json.dumps(v).encode("utf-8"),

--- a/agents/sdk/base.py
+++ b/agents/sdk/base.py
@@ -87,6 +87,9 @@ class BaseAgent:
             self.topic_subscriptions = list(topic_subscriptions)
         # Keep the legacy ``topic`` attribute for backward compatibility.
         self.topic = self.topic_subscriptions[0]
+        if KafkaConsumer is None or KafkaProducer is None:
+            msg = "kafka-python library is required to use BaseAgent"
+            raise RuntimeError(msg)
         self.consumer = KafkaConsumer(
             *self.topic_subscriptions,
             bootstrap_servers=bootstrap_servers,

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -247,3 +247,17 @@ def test_multiple_agents_start_metrics_on_distinct_ports():
         mock_start.assert_has_calls([call(8001), call(8002)], any_order=True)
         assert mock_start.call_count == 2
 
+
+def test_emit_event_missing_kafka_dependency():
+    with patch("agents.sdk.KafkaProducer", None):
+        with pytest.raises(RuntimeError, match="kafka-python library is required"):
+            sdk.emit_event("t", {"a": 1}, user_id="u1")
+
+
+def test_base_agent_missing_kafka_dependency():
+    with patch("agents.sdk.base.KafkaConsumer", None), patch(
+        "agents.sdk.base.KafkaProducer", None
+    ):
+        with pytest.raises(RuntimeError, match="kafka-python library is required"):
+            sdk.BaseAgent("topic", metrics_port=None)
+


### PR DESCRIPTION
## Summary
- Raise a clear RuntimeError if `KafkaProducer`/`KafkaConsumer` are unavailable
- Add tests ensuring SDK functions fail gracefully without kafka-python

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fcbaa26c832697d5ad874abd05b2