### PR TITLE
Handle request errors in explainability agent

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -46,7 +46,7 @@ class ExplainabilityAgent(BaseAgent):
             )
             resp.raise_for_status()
             data = resp.json()
-        except Exception as exc:  # pragma: no cover - network errors
+        except requests.RequestException as exc:  # pragma: no cover - network errors
             logger.error("Failed to fetch actions: %s", exc)
             return
         actions = data.get("actions", [])

--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -135,10 +136,14 @@ def test_request_exception_logged(
 ) -> None:
     event = {"analysis_id": "123", "user_id": "user1"}
     with patch("agents.explainability_agent.check_permission", return_value=True), \
-         patch("agents.explainability_agent.requests.get", side_effect=Exception("boom")):
+         patch(
+             "agents.explainability_agent.requests.get",
+             side_effect=requests.RequestException("boom"),
+         ):
         with caplog.at_level(logging.ERROR):
             agent.handle_event(event)
     assert "Failed to fetch actions" in caplog.text
+    assert "boom" in caplog.text
     agent.emit.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Catch `requests.RequestException` when fetching analysis actions and log error
- Ensure explainability agent test asserts the error message and no emission

## Testing
- `poetry run ruff check agents/explainability_agent/__init__.py tests/test_explainability_agent.py`
- `pytest tests/test_explainability_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8a38ef8c8326a627975ee6b1f436