### PR TITLE
Use BaseAgent identifier injection for FinRL strategist

### DIFF
--- a/agents/finrl_strategist/__init__.py
+++ b/agents/finrl_strategist/__init__.py
@@ -88,9 +88,7 @@ class FinRLStrategist(BaseAgent):
             for ticker, action in result.items():
                 topic = signals.get(action)
                 if topic:
-                    payload = {"ticker": ticker, "user_id": self.user_id}
-                    if self.group_id is not None:
-                        payload["group_id"] = self.group_id
+                    payload = {"ticker": ticker}
                     self.emit(
                         topic,
                         payload,


### PR DESCRIPTION
## Summary
- Rely on BaseAgent to inject `user_id`/`group_id` when emitting FinRL strategist signals
- Test that emitted events exclude identifiers while Kafka payload still includes them
- Ensure no signals are emitted when permission checks fail

## Testing
- `poetry run ruff check agents/finrl_strategist/__init__.py tests/test_finrl_strategist.py`
- `pytest tests/test_finrl_strategist.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8a3751488326a0abe1059cc65131