### PR TITLE
Remove manual identifiers from eureka watcher payload

### DIFF
--- a/agents/eureka_watcher/__init__.py
+++ b/agents/eureka_watcher/__init__.py
@@ -67,10 +67,7 @@ class EurekaWatcher(BaseAgent):
                     "idea": event.get("id"),
                     "doc": doc.get("id"),
                     "similarity": sim,
-                    "user_id": self.user_id,
                 }
-                if self.group_id is not None:
-                    payload["group_id"] = self.group_id
                 self.emit(
                     "ume.events.suggested_task",
                     payload,

--- a/tests/test_eureka_watcher.py
+++ b/tests/test_eureka_watcher.py
@@ -32,8 +32,10 @@ def test_watcher_emits_for_similar_doc() -> None:
         payload = args[1]
         assert payload["idea"] == "idea1"
         assert payload["doc"] == "doc1"
-        assert payload["user_id"] == "u1"
+        assert "user_id" not in payload
+        assert "group_id" not in payload
         assert kwargs["user_id"] == "u1"
+        assert kwargs["group_id"] is None
 
 
 def test_watcher_ignores_dissimilar_doc() -> None:


### PR DESCRIPTION
## Summary
- stop including `user_id` and `group_id` in eureka watcher payloads
- expect identifier-free payloads in eureka watcher tests

## Testing
- `poetry run ruff check agents/eureka_watcher/__init__.py tests/test_eureka_watcher.py`
- `pytest tests/test_eureka_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8a36e00c832697dfeafeebc16e5d