### PR TITLE
Default to UTC when timezone missing

### DIFF
--- a/tests/test_calendar_nlp.py
+++ b/tests/test_calendar_nlp.py
@@ -40,7 +40,7 @@ def test_parses_and_emits_event(agent: tuple[CalendarNLPAgent, MagicMock]) -> No
     llm.assert_called_once_with({
         "text": "Lunch with Sam at noon",
         "current_datetime": ANY,
-        "timezone": None,
+        "timezone": "UTC",
     })
     agent_instance.emit.assert_called_once()
     topic, payload = agent_instance.producer.send.call_args[0]


### PR DESCRIPTION
## Summary
- default CalendarNLP payload timezone to "UTC" when no event or config timezone is provided
- allow CalendarNLP agent main entrypoint to run without a config file
- adjust tests for UTC fallback

## Testing
- `ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcbbbe1548326a219e9676394fbee