### PR TITLE
Handle invalid UME responses in EurekaWatcher

### DIFF
--- a/agents/eureka_watcher/__init__.py
+++ b/agents/eureka_watcher/__init__.py
@@ -52,10 +52,14 @@ class EurekaWatcher(BaseAgent):
             logger.info("Permission denied for %s", self.user_id)
             return
         try:
-            docs = ume_query(self.docs_endpoint, {"vector": vector}).get("docs", [])
+            result = ume_query(self.docs_endpoint, {"vector": vector})
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("UME query failed: %s", exc)
             return
+        if not isinstance(result, dict):
+            logger.error("UME query returned invalid result: %s", result)
+            return
+        docs = result.get("docs", [])
         for doc in docs:
             doc_vec = doc.get("vector")
             if not isinstance(doc_vec, Sequence):

--- a/tests/test_eureka_watcher.py
+++ b/tests/test_eureka_watcher.py
@@ -52,3 +52,21 @@ def test_watcher_ignores_dissimilar_doc() -> None:
         watcher.handle_event(event)
         cp.assert_called_once_with("u1", "suggest", None)
         mock_emit.assert_not_called()
+
+
+def test_watcher_handles_none_response() -> None:
+    event = {"id": "idea1", "vector": [1.0, 0.0]}
+    with (
+        patch("agents.eureka_watcher.ume_query", return_value=None),
+        patch("agents.sdk.base.KafkaConsumer"),
+        patch("agents.sdk.base.KafkaProducer"),
+        patch("agents.sdk.base.start_http_server"),
+        patch.object(EurekaWatcher, "emit") as mock_emit,
+        patch("agents.eureka_watcher.check_permission", return_value=True) as cp,
+        patch("agents.eureka_watcher.logger") as mock_logger,
+    ):
+        watcher = EurekaWatcher("http://example", user_id="u1")
+        watcher.handle_event(event)
+        cp.assert_called_once_with("u1", "suggest", None)
+        mock_emit.assert_not_called()
+        mock_logger.error.assert_called_once()


### PR DESCRIPTION
## Summary
- Validate `ume_query` returns a dict before accessing docs in EurekaWatcher
- Add unit test covering `None` response from `ume_query`

## Testing
- `ruff check agents/eureka_watcher/__init__.py tests/test_eureka_watcher.py`
- `pytest tests/test_eureka_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_689bcbbb6294832699ebcdcd6ba17b89