### PR TITLE
Handle UME query failures with None

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -118,6 +118,7 @@ def test_calendar_nlp_entrypoint(tmp_path: Path) -> None:
     (tmp_path / "requests" / "__init__.py").write_text(
         "def post(*a,**k):\n    class R:\n        def raise_for_status(self):\n            pass\n        def json(self):\n            return {}\n    return R()\n"
     )
+    (tmp_path / "config.toml").write_text("[calendar_nlp]\n")
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -53,6 +53,13 @@ def test_ume_query_posts_and_returns_json():
         mock_post.assert_called_once()
 
 
+def test_ume_query_network_error_returns_none():
+    with patch(
+        "agents.sdk.requests.post", side_effect=requests.RequestException
+    ):
+        assert sdk.ume_query("http://example", {"q": 1}) is None
+
+
 def test_ume_query_uses_sidecar(monkeypatch):
     with patch("agents.sdk.requests.post") as mock_post:
         mock_resp = MagicMock()


### PR DESCRIPTION
## Summary
- return `None` from `ume_query` on network failures
- treat `None` responses as permission failures
- add test coverage for `ume_query` failure path
- ensure calendar NLP entrypoint test provides a config file

## Testing
- `ruff check agents/sdk/__init__.py tests/test_sdk.py tests/test_entrypoints.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcbbcfaf08326905267473877d21b