### PR TITLE
Check write permission before fetching Plaid transactions

### DIFF
--- a/agents/plaid_sync/__init__.py
+++ b/agents/plaid_sync/__init__.py
@@ -55,13 +55,13 @@ class PlaidSync(BaseAgent):
         if not check_permission(user_id, READ_ACTION, group_id):
             logger.info("Read permission denied for %s", user_id)
             return []
+        if not check_permission(user_id, WRITE_ACTION, group_id):
+            logger.info("Write permission denied for %s", user_id)
+            return []
         try:
             transactions = self.plaid.fetch_transactions(user_id)
         except Exception:  # pragma: no cover - defensive
             logger.exception("Failed to fetch transactions for %s", user_id)
-            return []
-        if not check_permission(user_id, WRITE_ACTION, group_id):
-            logger.info("Write permission denied for %s", user_id)
             return []
         for tx in transactions:
             payload = tx.copy()


### PR DESCRIPTION
## Summary
- verify both read and write permissions before fetching Plaid transactions
- test permission ordering and handle_event permission failures

## Testing
- `ruff check agents/plaid_sync/__init__.py tests/test_plaid_sync.py`
- `pytest tests/test_plaid_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bd46b252483269c8842ceef77da07