### PR TITLE
Read event user/group identifiers in EurekaWatcher

### DIFF
--- a/agents/eureka_watcher/__init__.py
+++ b/agents/eureka_watcher/__init__.py
@@ -44,12 +44,14 @@ class EurekaWatcher(BaseAgent):
         self.group_id = group_id
 
     def handle_event(self, event: dict[str, Any]) -> None:  # type: ignore[override]
+        user_id = event.get("user_id", self.user_id)
+        group_id = event.get("group_id", self.group_id)
         vector = event.get("vector")
         if not isinstance(vector, Sequence):
             logger.debug("Event missing vector: %s", event)
             return
-        if not check_permission(self.user_id, "suggest", self.group_id):
-            logger.info("Permission denied for %s", self.user_id)
+        if not check_permission(user_id, "suggest", group_id):
+            logger.info("Permission denied for %s", user_id)
             return
         try:
             result = ume_query(self.docs_endpoint, {"vector": vector})
@@ -75,8 +77,8 @@ class EurekaWatcher(BaseAgent):
                 self.emit(
                     "ume.events.suggested_task",
                     payload,
-                    user_id=self.user_id,
-                    group_id=self.group_id,
+                    user_id=user_id,
+                    group_id=group_id,
                 )
 
 

--- a/tests/test_eureka_watcher.py
+++ b/tests/test_eureka_watcher.py
@@ -54,6 +54,31 @@ def test_watcher_ignores_dissimilar_doc() -> None:
         mock_emit.assert_not_called()
 
 
+def test_watcher_event_identifiers_override_defaults() -> None:
+    event = {
+        "id": "idea1",
+        "vector": [1.0, 0.0],
+        "user_id": "u2",
+        "group_id": "g1",
+    }
+    docs = {"docs": [{"id": "doc1", "vector": [1.0, 0.0]}]}
+    with (
+        patch("agents.eureka_watcher.ume_query", return_value=docs),
+        patch("agents.sdk.base.KafkaConsumer"),
+        patch("agents.sdk.base.KafkaProducer"),
+        patch("agents.sdk.base.start_http_server"),
+        patch.object(EurekaWatcher, "emit") as mock_emit,
+        patch("agents.eureka_watcher.check_permission", return_value=True) as cp,
+    ):
+        watcher = EurekaWatcher("http://example", user_id="u1", group_id="g0")
+        watcher.handle_event(event)
+        cp.assert_called_once_with("u2", "suggest", "g1")
+        mock_emit.assert_called_once()
+        _, kwargs = mock_emit.call_args
+        assert kwargs["user_id"] == "u2"
+        assert kwargs["group_id"] == "g1"
+
+
 def test_watcher_handles_none_response() -> None:
     event = {"id": "idea1", "vector": [1.0, 0.0]}
     with (


### PR DESCRIPTION
## Summary
- Pull user and group identifiers from incoming events in EurekaWatcher, falling back to defaults
- Test event handling with and without explicit user/group identifiers

## Testing
- `ruff check agents/eureka_watcher/__init__.py tests/test_eureka_watcher.py`
- `pytest tests/test_eureka_watcher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689be1af1c648326a22e8eea5bacdcd2