### PR TITLE
Send user and group identifiers in explainability requests

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -41,8 +41,13 @@ class ExplainabilityAgent(BaseAgent):
             logger.info("Permission denied for user %s", user_id)
             return
         try:
+            params = {"user_id": user_id}
+            if group_id:
+                params["group_id"] = group_id
             resp = requests.get(
-                f"{self.engine_url}/analysis/{analysis_id}/actions", timeout=10
+                f"{self.engine_url}/analysis/{analysis_id}/actions",
+                params=params,
+                timeout=10,
             )
             resp.raise_for_status()
             try:


### PR DESCRIPTION
## Summary
- include user_id and optional group_id when requesting actions for explainability
- check query parameters in explainability agent tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c94f44ed48326b4d113146202c645