### PR TITLE
Use timezone-aware UTC timestamp in Calendar NLP agent

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -59,7 +59,7 @@ class CalendarNLPAgent(BaseAgent):
                 return
         else:
             timezone = "UTC"
-            now = datetime.now(dt_timezone.utc)
+            now = datetime.now(ZoneInfo("UTC"))
         payload = {
             "text": text,
             "current_datetime": now.isoformat(),


### PR DESCRIPTION
## Summary
- ensure CalendarNLPAgent emits timezone-aware UTC timestamps using `datetime.now(ZoneInfo("UTC"))`
- drop unnecessary `timezone` import

## Testing
- `ruff check agents/calendar_nlp/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c94f3d15c832685e4151702e50f43