### PR TITLE
Validate calendar event datetimes

### DIFF
--- a/agents/calendar_nlp/__init__.py
+++ b/agents/calendar_nlp/__init__.py
@@ -76,10 +76,16 @@ class CalendarNLPAgent(BaseAgent):
         if not title or not start_time or not end_time:
             logger.warning("Missing required fields in LLM result: %s", result)
             return
+        try:
+            start_dt = datetime.fromisoformat(start_time)
+            end_dt = datetime.fromisoformat(end_time)
+        except ValueError:
+            logger.warning("Invalid datetime format in LLM result: %s", result)
+            return
         calendar_event = {
             "title": title,
-            "start_time": start_time,
-            "end_time": end_time,
+            "start_time": start_dt.isoformat(),
+            "end_time": end_dt.isoformat(),
             "location": result.get("location"),
             "description": result.get("description"),
             "is_all_day": result.get("is_all_day"),


### PR DESCRIPTION
## Summary
- parse `start_time` and `end_time` with `datetime.fromisoformat`
- skip emitting calendar events when datetimes are missing or invalid
- add tests for valid, invalid, and missing datetime fields

## Testing
- `python -m ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cdf453b5483268d24d21b11db047c