### PR TITLE
Add write permission check to ExplainabilityAgent

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -81,6 +81,9 @@ class ExplainabilityAgent(BaseAgent):
             pros = "; ".join(str(p) for p in pros_items if isinstance(p, str))
             cons = "; ".join(str(c) for c in cons_items if isinstance(c, str))
             explanations.append({"action": name, "pros": pros, "cons": cons})
+        if not check_permission(user_id, "analysis:write", group_id):
+            logger.info("Write permission denied for user %s", user_id)
+            return
         payload = {"analysis_id": analysis_id, "explanations": explanations}
         self.emit(
             "finance.explain.result",

--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -36,7 +36,10 @@ def test_explainability_agent_emits(agent: ExplainabilityAgent) -> None:
     with patch("agents.explainability_agent.requests.get", return_value=mock_resp) as mock_get, \
          patch("agents.explainability_agent.check_permission", return_value=True) as mock_perm:
         agent.handle_event(event)
-    mock_perm.assert_called_once_with("user1", "analysis:read", None)
+    mock_perm.assert_has_calls(
+        [call("user1", "analysis:read", None), call("user1", "analysis:write", None)]
+    )
+    assert mock_perm.call_count == 2
     mock_get.assert_called_once_with(
         "http://engine/analysis/123/actions",
         params={"user_id": "user1"},
@@ -111,7 +114,10 @@ def test_group_id_propagates() -> None:
          patch("agents.explainability_agent.check_permission", return_value=True) as mock_perm:
         agent = ExplainabilityAgent("http://engine")
         agent.handle_event({"analysis_id": "123", "user_id": "u1", "group_id": "g1"})
-    mock_perm.assert_called_once_with("u1", "analysis:read", "g1")
+    mock_perm.assert_has_calls(
+        [call("u1", "analysis:read", "g1"), call("u1", "analysis:write", "g1")]
+    )
+    assert mock_perm.call_count == 2
     mock_get.assert_called_once_with(
         "http://engine/analysis/123/actions",
         params={"user_id": "u1", "group_id": "g1"},


### PR DESCRIPTION
## Summary
- ensure ExplainabilityAgent verifies analysis:write permissions before emitting results
- adjust explainability agent tests for additional write permission check

## Testing
- `ruff check agents/explainability_agent/__init__.py tests/test_explainability_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d40b830908326b3be242702bc4ee5