### PR TITLE
test: ensure run_weekly skips non-monday

### DIFF
--- a/tests/test_finrl_strategist.py
+++ b/tests/test_finrl_strategist.py
@@ -16,12 +16,6 @@ class Monday(date):
         return cls(2024, 1, 1)
 
 
-class Tuesday(date):
-    @classmethod
-    def today(cls):
-        return cls(2024, 1, 2)
-
-
 def test_run_weekly_emits_signals():
     predictions = {"SPY": "buy", "AAPL": "sell"}
     with patch("agents.sdk.base.KafkaConsumer"), \
@@ -103,11 +97,12 @@ def test_run_weekly_not_monday_emits_nothing():
     with (
         patch("agents.sdk.base.KafkaConsumer"),
         patch("agents.sdk.base.KafkaProducer") as mock_producer_cls,
-        patch("agents.finrl_strategist.date", Tuesday),
+        patch("agents.finrl_strategist.date") as mock_date,
         patch.object(FinRLStrategist, "backtest_last_30d") as backtest,
         patch.object(FinRLStrategist, "emit") as mock_emit,
         patch("agents.finrl_strategist.check_permission") as cp,
     ):
+        mock_date.today.return_value = date(2024, 1, 2)
         mock_producer = MagicMock()
         mock_producer_cls.return_value = mock_producer
         strategist = FinRLStrategist(["SPY"], user_id="u1")


### PR DESCRIPTION
## Summary
- patch `date.today()` to return a Tuesday in non-Monday test
- verify `run_weekly` does nothing when not Monday

## Testing
- `ruff check tests/test_finrl_strategist.py`
- `pytest tests/test_finrl_strategist.py::test_run_weekly_not_monday_emits_nothing -q`


------
https://chatgpt.com/codex/tasks/task_e_689e051c8e8c832697742ccf6b08a02b