### PR TITLE
Remove CryptoBot permission override

### DIFF
--- a/agents/crypto_bot/__main__.py
+++ b/agents/crypto_bot/__main__.py
@@ -10,8 +10,6 @@ from ..config import Config
 
 async def _run(cfg_path: Path) -> None:
     import agents.crypto_bot as module
-
-    module.check_permission = lambda *a, **k: True
     user_id = os.environ.get("USER_ID", "crypto")
     group_id = os.environ.get("GROUP_ID")
     bot = module.CryptoBot(Config(cfg_path), user_id=user_id, group_id=group_id)

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 
 def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
@@ -32,14 +33,18 @@ def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])
-
-    result = subprocess.run(
-        [sys.executable, "-m", "agents.crypto_bot"],
-        cwd=tmp_path,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    sys.path.insert(0, str(repo_root))
+    try:
+        with patch("agents.crypto_bot.check_permission", return_value=True):
+            result = subprocess.run(
+                [sys.executable, "-m", "agents.crypto_bot"],
+                cwd=tmp_path,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+    finally:
+        sys.path.remove(str(repo_root))
     assert result.returncode == 0, result.stderr
 
 


### PR DESCRIPTION
## Summary
- rely on default permission check in CryptoBot entrypoint
- patch CryptoBot entrypoint test to stub permission check

## Testing
- `pytest tests/test_entrypoints.py::test_crypto_bot_entrypoint -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4010dd7883269f8f9d583bf751dc