### PR TITLE
Remove FinRL permission override

### DIFF
--- a/agents/finrl_strategist/__main__.py
+++ b/agents/finrl_strategist/__main__.py
@@ -24,8 +24,6 @@ def entrypoint() -> None:
     cfg_path = Path(args.config)
     cfg = Config(cfg_path) if cfg_path.exists() else None
     import agents.finrl_strategist as module
-
-    module.check_permission = lambda *a, **k: True
     asyncio.run(main(cfg))
 
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -60,13 +60,18 @@ def test_finrl_strategist_entrypoint(tmp_path: Path) -> None:
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])
-    result = subprocess.run(
-        [sys.executable, "-m", "agents.finrl_strategist"],
-        cwd=tmp_path,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    sys.path.insert(0, str(repo_root))
+    try:
+        with patch("agents.finrl_strategist.check_permission", return_value=True):
+            result = subprocess.run(
+                [sys.executable, "-m", "agents.finrl_strategist"],
+                cwd=tmp_path,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+    finally:
+        sys.path.remove(str(repo_root))
     assert result.returncode == 0, result.stderr
 
 


### PR DESCRIPTION
## Summary
- Remove hard-coded permission bypass in FinRL strategist entrypoint
- Patch test to stub FinRL strategist permission check

## Testing
- `python -m py_compile agents/finrl_strategist/__main__.py tests/test_entrypoints.py`
- `pytest tests/test_entrypoints.py::test_finrl_strategist_entrypoint -q`


------
https://chatgpt.com/codex/tasks/task_e_689f456661488326a802249d92eed950