### PR TITLE
Handle non-request exceptions in calendar sync

### DIFF
--- a/agents/calendar_sync/__init__.py
+++ b/agents/calendar_sync/__init__.py
@@ -52,7 +52,7 @@ class CalendarSync(BaseAgent):
                 response = requests.post(
                     self.cal_endpoint, json=payload, timeout=10
                 )
-            except Exception as exc:  # pragma: no cover - network errors
+            except requests.RequestException as exc:  # pragma: no cover - network errors
                 logger.error("Failed to sync to Cal.com: %s", exc)
                 return
             if 200 <= response.status_code < 300:


### PR DESCRIPTION
## Summary
- Avoid swallowing non-network errors by only catching `requests.RequestException`
- Add regression test ensuring unexpected exceptions bubble up

## Testing
- `ruff check agents/calendar_sync/__init__.py tests/test_calendar_sync.py`
- `pytest tests/test_calendar_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689f492ecc448326b5f767d9538979bd