### PR TITLE
Validate calendar NLP times and recurrence

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -51,7 +51,7 @@ def test_crypto_bot_entrypoint(tmp_path: Path) -> None:
 def test_finrl_strategist_entrypoint(tmp_path: Path) -> None:
     (tmp_path / "kafka").mkdir()
     (tmp_path / "kafka" / "__init__.py").write_text(
-        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\n" "class KafkaProducer:\n    def __init__(self,*a,**k):\n        pass\n    def send(self,*a,**k):\n        pass\n    def flush(self):\n        pass\n    def close(self):\n        pass\n"
+        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\n    def close(self):\n        pass\n" "class KafkaProducer:\n    def __init__(self,*a,**k):\n        pass\n    def send(self,*a,**k):\n        pass\n    def flush(self):\n        pass\n    def close(self):\n        pass\n"
     )
     (tmp_path / "prometheus_client").mkdir()
     (tmp_path / "prometheus_client" / "__init__.py").write_text(
@@ -105,7 +105,7 @@ def test_eureka_watcher_entrypoint(tmp_path: Path) -> None:
 def test_calendar_nlp_entrypoint(tmp_path: Path) -> None:
     (tmp_path / "kafka").mkdir()
     (tmp_path / "kafka" / "__init__.py").write_text(
-        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\n"
+        "class KafkaConsumer:\n    def __init__(self,*a,**k):\n        pass\n    def __iter__(self):\n        return iter([])\n    def close(self):\n        pass\n"
         "class KafkaProducer:\n    def __init__(self,*a,**k):\n        pass\n    def send(self,*a,**k):\n        pass\n    def flush(self):\n        pass\n    def close(self):\n        pass\n"
     )
     (tmp_path / "prometheus_client").mkdir()


### PR DESCRIPTION
## Summary
- enforce timezone-aware datetimes and end-after-start validation in CalendarNLPAgent
- normalize and validate recurrence strings
- test invalid time order, naive datetimes, recurrence handling
- add missing `KafkaConsumer.close` stub so FinRL strategist entrypoint test shuts down cleanly

## Testing
- `ruff check agents/calendar_nlp/__init__.py tests/test_calendar_nlp.py tests/test_entrypoints.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5830c974832685b3a19a9bc3ce09