### PR TITLE
Ensure Plaid sync emits full transaction details

### DIFF
--- a/agents/plaid_sync/__init__.py
+++ b/agents/plaid_sync/__init__.py
@@ -85,9 +85,10 @@ class PlaidSync(BaseAgent):
             logger.exception("Failed to fetch transactions for %s", user_id)
             return []
         for tx in transactions:
+            payload = tx.copy()
             self.emit(
                 "plaid.transaction.synced",
-                tx,
+                payload,
                 user_id=user_id,
                 group_id=group_id,
             )

--- a/tests/test_plaid_sync.py
+++ b/tests/test_plaid_sync.py
@@ -51,8 +51,7 @@ def test_permission_checks_and_event_emission(agent: PlaidSync) -> None:
     assert topic == "plaid.transaction.synced"
     assert kwargs["user_id"] == "u1"
     assert kwargs["group_id"] == "g1"
-    assert payload["amount"] == 100
-    assert payload["account_id"] == "a1"
+    assert payload == {"id": "t1", "amount": 100, "account_id": "a1"}
     assert "user_id" not in payload
     assert "group_id" not in payload
 


### PR DESCRIPTION
## Summary
- preserve all transaction fields by copying payload before emission
- verify emitted events include amount and account ID details

## Testing
- `/tmp/venv/bin/ruff check agents/plaid_sync/__init__.py tests/test_plaid_sync.py`
- `/tmp/venv/bin/python -m pytest tests/test_plaid_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b037a554832683cdc4a3087d908e