### PR TITLE
Improve explainability agent schema validation and summaries

### DIFF
--- a/agents/explainability_agent/__init__.py
+++ b/agents/explainability_agent/__init__.py
@@ -78,9 +78,10 @@ class ExplainabilityAgent(BaseAgent):
         explanations = []
         for action in actions:
             if not isinstance(action, dict):
+                logger.error("Invalid action entry: %s", action)
                 continue
             name = action.get("name")
-            if not isinstance(name, str):
+            if not isinstance(name, str) or not name:
                 name = "Unnamed action"
             pros_items = action.get("pros")
             if not isinstance(pros_items, list):
@@ -95,7 +96,10 @@ class ExplainabilityAgent(BaseAgent):
         if not check_permission(user_id, "analysis:write", group_id):
             logger.info("Write permission denied for user %s", user_id)
             return
+        summary_lines = [f"- {exp['action']}" for exp in explanations]
         payload = {"analysis_id": analysis_id, "explanations": explanations}
+        if len(summary_lines) > 1:
+            payload["summary"] = "\n".join(summary_lines)
         self.emit(
             "finance.explain.result",
             payload,

--- a/tests/test_explainability_agent.py
+++ b/tests/test_explainability_agent.py
@@ -363,4 +363,18 @@ def test_multi_action_explanations(agent: ExplainabilityAgent) -> None:
     assert second["action"] == "Unnamed action"
     assert second["pros"] == "- safety"
     assert second["cons"] == ""
+    assert payload["summary"] == "- invest\n- Unnamed action"
+
+
+def test_summary_not_included_for_single_action(agent: ExplainabilityAgent) -> None:
+    event = {"analysis_id": "123", "user_id": "user1"}
+    response = {"actions": [{"name": "invest", "pros": ["growth"], "cons": ["risk"]}]}
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response
+    mock_resp.raise_for_status.return_value = None
+    with patch("agents.explainability_agent.requests.get", return_value=mock_resp), \
+         patch("agents.explainability_agent.check_permission", return_value=True):
+        agent.handle_event(event)
+    payload = agent.emit.call_args[0][1]
+    assert "summary" not in payload
 


### PR DESCRIPTION
## Summary
- Validate ExplainabilityAgent responses and default missing action fields
- Provide bullet list summary when multiple actions are returned
- Test malformed responses and multi-action summaries

## Testing
- `ruff check agents/explainability_agent/__init__.py tests/test_explainability_agent.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b036b7808326bbc28f3421121542