### PR TITLE
Add file transfer utilities with integration tests

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -2,6 +2,7 @@ from .config import Config
 from .crypto_bot import CryptoBot
 from .calendar_sync import CalendarSync
 from .sdk import emit_event, ume_query, BaseAgent
+from .file_transfer import download_file, upload_file
 
 __all__ = [
     "Config",
@@ -10,4 +11,6 @@ __all__ = [
     "emit_event",
     "ume_query",
     "BaseAgent",
+    "upload_file",
+    "download_file",
 ]

--- a/agents/file_transfer.py
+++ b/agents/file_transfer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def upload_file(url: str, path: Path) -> bool:
+    """Upload a file to the given *url* using HTTP PUT.
+
+    Returns ``True`` on success, ``False`` if the request fails for any
+    reason.
+    """
+    try:
+        with path.open("rb") as fh:
+            response = requests.put(url, data=fh, timeout=10)
+        response.raise_for_status()
+        return True
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("File upload failed: %s", exc)
+        return False
+
+
+def download_file(url: str, dest: Path) -> bool:
+    """Download *url* and write the content to ``dest``.
+
+    Returns ``True`` when the download succeeds, ``False`` otherwise.
+    """
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        dest.write_bytes(response.content)
+        return True
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("File download failed: %s", exc)
+        return False
+
+
+__all__ = ["upload_file", "download_file"]

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import agents.file_transfer as ft
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Simple handler that stores uploads and serves the stored file."""
+
+    store: Path | None = None
+
+    def do_PUT(self) -> None:  # noqa: N802 - HTTP verb
+        assert self.store is not None
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length)
+        self.store.write_bytes(data)
+        self.send_response(200)
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802 - HTTP verb
+        assert self.store is not None
+        data = self.store.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt: str, *args) -> None:  # pragma: no cover - quiet
+        return
+
+
+def test_upload_and_download(tmp_path: Path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("hello world")
+    dest = tmp_path / "dest.txt"
+    _Handler.store = dest
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://{server.server_address[0]}:{server.server_port}"
+    try:
+        assert ft.upload_file(url, src)
+        out = tmp_path / "out.txt"
+        assert ft.download_file(url, out)
+        assert out.read_text() == "hello world"
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- provide upload_file and download_file helpers in new file_transfer module
- expose file transfer helpers through agents package
- add integration test covering upload and download via HTTP server

## Testing
- `ruff check agents/file_transfer.py tests/test_file_transfer.py agents/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb2a515483268edeb709698b9b6e