### PR TITLE
Add Stripe payment account and enforce processor connect interface

### DIFF
--- a/agents/payments/__init__.py
+++ b/agents/payments/__init__.py
@@ -1,0 +1,4 @@
+"""Payments module providing payment-related classes and interfaces."""
+
+from .stripe import StripeAccount  # noqa: F401
+from .processor import ProcessorInterface  # noqa: F401

--- a/agents/payments/database.py
+++ b/agents/payments/database.py
@@ -1,0 +1,21 @@
+"""Simple in-memory database interface for payment settings."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# In a real application this would interface with an actual database. For the
+# purposes of these agents and tests we store settings in a module-level
+# dictionary that can be patched in tests.
+_SETTINGS: Dict[str, Any] = {
+    "payment_gateways": {
+        "stripe": {
+            "api_key": "",  # Placeholder to be overridden in tests
+        }
+    }
+}
+
+
+def get_setting(name: str) -> Any:
+    """Return a setting by *name* from the in-memory database."""
+    return _SETTINGS.get(name)

--- a/agents/payments/processor.py
+++ b/agents/payments/processor.py
@@ -1,0 +1,30 @@
+"""Payment processor interface definitions."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Set, Type
+
+
+class ProcessorInterface:
+    """Base processor interface supporting versioning.
+
+    Subclasses may define available actions via the ``actions`` class attribute.
+    When a processor exposes a ``connect`` action it must also implement a
+    ``connect`` classmethod. The :meth:`versioned` classmethod enforces this
+    contract.
+    """
+
+    actions: ClassVar[Set[str]] = set()
+
+    @classmethod
+    def versioned(cls) -> Type["ProcessorInterface"]:
+        """Return a versioned interface for the processor.
+
+        Processors declaring a ``connect`` action must implement a ``connect``
+        classmethod. If absent, ``NotImplementedError`` is raised.
+        """
+
+        if "connect" in cls.actions and not hasattr(cls, "connect"):
+            msg = "Processors with a 'connect' action must define a connect classmethod"
+            raise NotImplementedError(msg)
+        return cls

--- a/agents/payments/stripe.py
+++ b/agents/payments/stripe.py
@@ -1,0 +1,27 @@
+"""Stripe payment account implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from .database import get_setting
+
+
+@dataclass
+class StripeAccount:
+    """Representation of a Stripe account.
+
+    Upon initialization the class loads gateway configuration from the database
+    settings. The configuration is stored in ``gateway_config``.
+    """
+
+    account_id: str
+    gateway_config: Dict[str, Any] = field(init=False)
+
+    def __post_init__(self) -> None:
+        settings = get_setting("payment_gateways") or {}
+        config = settings.get("stripe")
+        if config is None:
+            raise ValueError("Stripe settings not found in database")
+        self.gateway_config = config

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+import pytest
+
+from agents.payments.stripe import StripeAccount
+from agents.payments.processor import ProcessorInterface
+
+
+def test_stripe_account_loads_gateway_config():
+    with patch("agents.payments.stripe.get_setting") as mock_get:
+        mock_get.return_value = {"stripe": {"api_key": "secret"}}
+        account = StripeAccount("acct_1")
+        assert account.gateway_config == {"api_key": "secret"}
+        mock_get.assert_called_once_with("payment_gateways")
+
+
+def test_processor_requires_connect_classmethod_when_action_present():
+    class BadProcessor(ProcessorInterface):
+        actions = {"connect"}
+
+    with pytest.raises(NotImplementedError):
+        BadProcessor.versioned()
+
+    class GoodProcessor(ProcessorInterface):
+        actions = {"connect"}
+
+        @classmethod
+        def connect(cls):  # pragma: no cover - simple stub
+            return True
+
+    assert GoodProcessor.versioned() is GoodProcessor


### PR DESCRIPTION
## Summary
- implement StripeAccount class that loads gateway config from settings
- add ProcessorInterface requiring connect classmethod when connect action declared
- add tests for StripeAccount and processor interface

## Testing
- `ruff check agents/payments tests/test_payments.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb2963ec83269e153a141165a04f