### PR TITLE
Add decision service agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,50 @@ if not check_permission(user_id, "analysis:read"):
 
 All emitted events must include the originating `user_id` and optionally a `group_id`.
 
+## DecisionService
+
+Processes decision requests for financial analyses.
+
+**Topics**
+
+- Consumes: `finance.decision.request`
+- Produces: `finance.decision.result`
+
+**Payloads**
+
+- Incoming `finance.decision.request`
+
+  ```json
+  {"analysis_id": "a1", "decision": {"action": "buy"}, "user_id": "u1", "group_id": "g1"}
+  ```
+
+- Outgoing `finance.decision.result`
+
+  ```json
+  {
+    "analysis_id": "a1",
+    "decision": {"action": "buy"},
+    "user_id": "u1",
+    "group_id": "g1"
+  }
+  ```
+
+**Permission model**
+
+```python
+from agents.sdk import check_permission
+
+if check_permission(user_id, "analysis:decision", group_id):
+    agent.emit(
+        "finance.decision.result",
+        {"analysis_id": analysis_id, "decision": decision},
+        user_id=user_id,
+        group_id=group_id,
+    )
+```
+
+All emitted events must include the originating `user_id` and optionally a `group_id`.
+
 ## PlaidSyncAgent
 
 Synchronizes transactions from Plaid and emits updates.

--- a/agents/decision_service/__init__.py
+++ b/agents/decision_service/__init__.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from ..sdk import BaseAgent, check_permission
+from ..config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class DecisionService(BaseAgent):
+    """Agent that handles finance decision requests."""
+
+    topic_subscriptions = ["finance.decision.request"]
+
+    def __init__(self, *, bootstrap_servers: str = "localhost:9092") -> None:
+        super().__init__(
+            self.topic_subscriptions,
+            bootstrap_servers=bootstrap_servers,
+            group_id="decision-service",
+        )
+
+    def handle_event(self, event: dict[str, Any]) -> None:  # type: ignore[override]
+        analysis_id = event.get("analysis_id")
+        user_id = event.get("user_id")
+        group_id = event.get("group_id")
+        if not analysis_id or not user_id:
+            logger.debug("Missing analysis_id or user_id: %s", event)
+            return
+        if not check_permission(user_id, "analysis:decision", group_id):
+            logger.info("Permission denied for user %s", user_id)
+            return
+        decision = event.get("decision")
+        payload: dict[str, Any] = {"analysis_id": analysis_id}
+        if decision is not None:
+            payload["decision"] = decision
+        self.emit(
+            "finance.decision.result",
+            payload,
+            user_id=user_id,
+            group_id=group_id,
+        )
+
+
+async def main(config: Config | None = None) -> None:
+    """Run the decision service from configuration."""
+    section = config.get("decision_service", {}) if config else {}
+    bootstrap = section.get("bootstrap_servers", "localhost:9092")
+    agent = DecisionService(bootstrap_servers=bootstrap)
+    await asyncio.to_thread(agent.run)
+
+
+__all__ = ["DecisionService", "main"]

--- a/agents/decision_service/__main__.py
+++ b/agents/decision_service/__main__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+
+from ..config import Config
+from . import main
+
+
+def cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "config.toml"),
+        help="Path to configuration file",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = cli()
+    cfg_path = Path(args.config)
+    cfg = Config(cfg_path) if cfg_path.exists() else None
+    asyncio.run(main(cfg))

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.decision_service import DecisionService
+
+
+@pytest.fixture()
+def agent() -> DecisionService:
+    with (
+        patch("agents.sdk.base.KafkaConsumer"),
+        patch("agents.sdk.base.KafkaProducer"),
+        patch("agents.sdk.base.start_http_server"),
+    ):
+        ag = DecisionService()
+    ag.emit = MagicMock()
+    return ag
+
+
+def test_emits_result(agent: DecisionService) -> None:
+    event = {"analysis_id": "a1", "decision": {"action": "buy"}, "user_id": "u1"}
+    with patch("agents.decision_service.check_permission", return_value=True) as mock_perm:
+        agent.handle_event(event)
+    mock_perm.assert_called_once_with("u1", "analysis:decision", None)
+    agent.emit.assert_called_once()
+    topic, payload = agent.emit.call_args[0]
+    kwargs = agent.emit.call_args.kwargs
+    assert topic == "finance.decision.result"
+    assert payload == {"analysis_id": "a1", "decision": {"action": "buy"}}
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["group_id"] is None
+
+
+def test_group_id_propagates(agent: DecisionService) -> None:
+    event = {"analysis_id": "a1", "user_id": "u1", "group_id": "g1"}
+    with patch("agents.decision_service.check_permission", return_value=True) as mock_perm:
+        agent.handle_event(event)
+    mock_perm.assert_called_once_with("u1", "analysis:decision", "g1")
+    agent.emit.assert_called_once()
+    topic, payload = agent.emit.call_args[0]
+    kwargs = agent.emit.call_args.kwargs
+    assert topic == "finance.decision.result"
+    assert payload == {"analysis_id": "a1"}
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["group_id"] == "g1"
+
+
+def test_permission_denied(agent: DecisionService) -> None:
+    event = {"analysis_id": "a1", "user_id": "u1"}
+    with patch("agents.decision_service.check_permission", return_value=False) as mock_perm:
+        agent.handle_event(event)
+    mock_perm.assert_called_once_with("u1", "analysis:decision", None)
+    agent.emit.assert_not_called()
+
+
+def test_missing_fields(agent: DecisionService) -> None:
+    agent.handle_event({"user_id": "u1"})
+    agent.handle_event({"analysis_id": "a1"})
+    agent.emit.assert_not_called()


### PR DESCRIPTION
## Summary
- add decision service agent to handle `finance.decision.request` events
- document decision service payloads and permissions
- cover decision service with unit tests

## Testing
- `ruff check agents/decision_service tests/test_decision_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a336a059c48326b2f71bd56ddf8f35