### PR TITLE
Add permission checks to file transfer

### DIFF
--- a/agents/file_transfer.py
+++ b/agents/file_transfer.py
@@ -5,15 +5,26 @@ from pathlib import Path
 
 import requests
 
+from .sdk import check_permission
+
 logger = logging.getLogger(__name__)
 
 
-def upload_file(url: str, path: Path) -> bool:
+def upload_file(
+    url: str,
+    path: Path,
+    *,
+    user_id: str,
+    group_id: str | None = None,
+) -> bool:
     """Upload a file to the given *url* using HTTP PUT.
 
     Returns ``True`` on success, ``False`` if the request fails for any
-    reason.
+    reason. "file:write" permission is checked before uploading.
     """
+    if not check_permission(user_id, "file:write", group_id):
+        logger.info("Permission denied for %s", user_id)
+        return False
     try:
         with path.open("rb") as fh:
             response = requests.put(url, data=fh, timeout=10)
@@ -24,11 +35,21 @@ def upload_file(url: str, path: Path) -> bool:
         return False
 
 
-def download_file(url: str, dest: Path) -> bool:
+def download_file(
+    url: str,
+    dest: Path,
+    *,
+    user_id: str,
+    group_id: str | None = None,
+) -> bool:
     """Download *url* and write the content to ``dest``.
 
-    Returns ``True`` when the download succeeds, ``False`` otherwise.
+    Returns ``True`` when the download succeeds, ``False`` otherwise. "file:read"
+    permission is verified before downloading.
     """
+    if not check_permission(user_id, "file:read", group_id):
+        logger.info("Permission denied for %s", user_id)
+        return False
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest.mock import patch
 
 import agents.file_transfer as ft
 
@@ -43,10 +44,31 @@ def test_upload_and_download(tmp_path: Path) -> None:
     thread.start()
     url = f"http://{server.server_address[0]}:{server.server_port}"
     try:
-        assert ft.upload_file(url, src)
+        with patch("agents.file_transfer.check_permission", return_value=True) as cp:
+            assert ft.upload_file(url, src, user_id="u1", group_id="g1")
+            cp.assert_called_once_with("u1", "file:write", "g1")
         out = tmp_path / "out.txt"
-        assert ft.download_file(url, out)
+        with patch("agents.file_transfer.check_permission", return_value=True) as cp:
+            assert ft.download_file(url, out, user_id="u1", group_id="g1")
+            cp.assert_called_once_with("u1", "file:read", "g1")
         assert out.read_text() == "hello world"
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_permission_denied(tmp_path: Path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("data")
+    with patch("agents.file_transfer.check_permission", return_value=False) as cp, \
+         patch("agents.file_transfer.requests.put") as mock_put:
+        assert ft.upload_file("http://example.com", src, user_id="u1") is False
+    cp.assert_called_once_with("u1", "file:write", None)
+    mock_put.assert_not_called()
+
+    dest = tmp_path / "dest.txt"
+    with patch("agents.file_transfer.check_permission", return_value=False) as cp, \
+         patch("agents.file_transfer.requests.get") as mock_get:
+        assert ft.download_file("http://example.com", dest, user_id="u1") is False
+    cp.assert_called_once_with("u1", "file:read", None)
+    mock_get.assert_not_called()


### PR DESCRIPTION
## Summary
- require `user_id` and optional `group_id` for file transfers
- validate `file:write` and `file:read` permissions before upload/download
- extend tests for identifier handling and permission denial

## Testing
- `python -m pytest`
- `ruff check agents/file_transfer.py tests/test_file_transfer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3369eb6e48326a226ee41b2dc88de