### PR TITLE
Use calendar-specific permission actions

### DIFF
--- a/agents/calendar_sync/__init__.py
+++ b/agents/calendar_sync/__init__.py
@@ -40,7 +40,7 @@ class CalendarSync(BaseAgent):
         if appointment_id is None or start is None or not user_id:
             logger.debug("Invalid UME event: %s", event)
             return
-        if not check_permission(user_id, "read", group_id):
+        if not check_permission(user_id, "calendar:read", group_id):
             logger.info("Read permission denied for %s", user_id)
             return
         payload = {"id": appointment_id, "time": start, "user_id": user_id}
@@ -76,7 +76,7 @@ class CalendarSync(BaseAgent):
         if appointment_id is None or start is None or not user_id:
             logger.debug("Invalid Cal.com event: %s", event)
             return
-        if not check_permission(user_id, "write", group_id):
+        if not check_permission(user_id, "calendar:write", group_id):
             logger.info("Write permission denied for %s", user_id)
             return
         payload = {"id": appointment_id, "time": start, "user_id": user_id}

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -22,7 +22,7 @@ def test_handle_event_posts_to_cal():
          patch("agents.calendar_sync.check_permission", return_value=True) as cp:
         mock_post.return_value.status_code = 200
         agent.handle_event({"id": "1", "time": "t", "user_id": "u1", "group_id": "g1"})
-        cp.assert_called_once_with("u1", "read", "g1")
+        cp.assert_called_once_with("u1", "calendar:read", "g1")
         mock_post.assert_called_once_with(
             "http://api",
             json={"id": "1", "time": "t", "user_id": "u1", "group_id": "g1"},
@@ -101,7 +101,7 @@ def test_handle_event_permission_denied():
     with patch("agents.calendar_sync.check_permission", return_value=False) as cp, \
          patch("agents.calendar_sync.requests.post") as mock_post:
         agent.handle_event({"id": "1", "time": "t", "user_id": "u1"})
-    cp.assert_called_once_with("u1", "read", None)
+    cp.assert_called_once_with("u1", "calendar:read", None)
     mock_post.assert_not_called()
 
 
@@ -113,7 +113,7 @@ def test_handle_cal_event_emits_task_reschedule():
     agent.emit = MagicMock()
     with patch("agents.calendar_sync.check_permission", return_value=True) as cp:
         agent.handle_cal_event({"id": "2", "time": "t", "user_id": "u1", "group_id": "g1"})
-    cp.assert_called_once_with("u1", "write", "g1")
+    cp.assert_called_once_with("u1", "calendar:write", "g1")
     agent.emit.assert_called_once()
     topic, payload = agent.emit.call_args[0]
     kwargs = agent.emit.call_args[1]
@@ -131,7 +131,7 @@ def test_handle_cal_event_permission_denied():
     agent.emit = MagicMock()
     with patch("agents.calendar_sync.check_permission", return_value=False) as cp:
         agent.handle_cal_event({"id": "2", "time": "t", "user_id": "u1"})
-    cp.assert_called_once_with("u1", "write", None)
+    cp.assert_called_once_with("u1", "calendar:write", None)
     agent.emit.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- scope calendar permissions to `calendar:read` and `calendar:write`
- adjust tests for new calendar permission actions

## Testing
- `ruff check agents/calendar_sync/__init__.py tests/test_calendar_sync.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3369f939c8326876986a269338146